### PR TITLE
Allow file pipeline to follow redirects

### DIFF
--- a/osp_scraper/pipelines.py
+++ b/osp_scraper/pipelines.py
@@ -254,6 +254,9 @@ class WarcFilesPipeline(FilesPipeline):
         return path_from_warc(record, info.spider.run_id)
 
     def _check_media_to_download(self, result, request, info):
+        # By default, scrapy will not follow redirects when downloading files.
+        # This allows the file pipeline to follow redirects instead of just giving a 
+        # warning and not downloading the file.
         x = super()._check_media_to_download(result, request, info)
         request.meta['handle_httpstatus_all'] = False
         return x

--- a/osp_scraper/pipelines.py
+++ b/osp_scraper/pipelines.py
@@ -252,3 +252,8 @@ class WarcFilesPipeline(FilesPipeline):
             record = response.meta['warc_record']
 
         return path_from_warc(record, info.spider.run_id)
+
+    def _check_media_to_download(self, result, request, info):
+        x = super()._check_media_to_download(result, request, info)
+        request.meta['handle_httpstatus_all'] = False
+        return x


### PR DESCRIPTION
@wearpants This is the _hack_ that I mentioned for getting the file pipeline to follow redirects instead of just giving a warning and not downloading the file.  I couldn't figure out how to do this for individual spiders, so we should verify somehow that it won't break anything else.