### PR TITLE
Adding script and scraper for downloading files listed in CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,10 @@ ends with a `/` it will be used-as is; otherwise the final path component is
 assumed to be a filename and will be dropped.
 
 The `edu_repo_crawler.py` works with the Google spreadsheet: "USA EDU Repo"
+
+## Downloading files listed in CSV
+
+If you use a tool such as (OutWit)[https://www.outwit.com/] to get file URLs,
+you can use the `bin/download_files.py` script to save these files as WARCs.  
+The spreadsheet must have `Source Url` and `Document Url` columns.
+

--- a/bin/download_files.py
+++ b/bin/download_files.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import logging
+
+import click
+
+from osp_scraper.tasks import crawl
+
+log = logging.getLogger('file_crawler')
+
+@click.command()
+@click.argument('csv_file', type=click.Path(exists=True))
+@click.option(
+    '--local',
+    default=False,
+    is_flag=True,
+    help="Run spiders locally instead of queueing them"
+)
+def main(csv_file, local):
+    crawl_func = crawl if local else crawl.delay
+
+    crawl_func("file_downloader", csv_file=csv_file)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/osp_scraper/spiders/file_scraper.py
+++ b/osp_scraper/spiders/file_scraper.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import csv
+from itertools import groupby
+from operator import itemgetter
+
+from ..spiders.CustomSpider import CustomSpider
+from ..items import PageItem
+
+class FileDownloader(CustomSpider):
+    name = "file_downloader"
+
+    # Workaround since yielding PageItems from start_requests isn't allowed
+    start_urls = ["http://example.com/"]
+
+    def parse(self, response):
+        with open(self.csv_file) as file:
+            rows = csv.DictReader(file)
+
+            for source, group in groupby(rows, itemgetter('Source Url')):
+                meta = {
+                    'source_url': source,
+                    'source_anchor': "",
+                    'depth': 1,
+                    'hops_from_seed': 1,
+                }
+
+                file_urls = [(row.get('Document Url'), meta) for row in group]
+
+                yield PageItem(
+                    url=source,
+                    content=b"",
+                    headers={},
+                    status=200,
+                    source_url="",
+                    source_anchor="",
+                    depth=1,
+                    hops_from_seed=1,
+                    file_urls=file_urls
+                )


### PR DESCRIPTION
This adds a script that can be run to generate WARC files from a list of files in a CSV.  It creates `PageItems` for each of the Source URLs in the CSV with all of the Document URLs as `file_urls`, so that the Warc Pipelines will automatically download the files and generate WARCs.  This required a workaround of requesting a dummy url (http://example.com/), and yielding `PageItems` from the handler, as yielding `PageItems` directly from `start_urls` is not permitted. 