### PR TITLE
Add Northern Michigan University scraper

### DIFF
--- a/osp_scraper/spiders/nmu.py
+++ b/osp_scraper/spiders/nmu.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+import scrapy
+
+from ..spiders.CustomSpider import CustomSpider
+
+class NMUSpider(CustomSpider):
+    name = "nmu"
+
+    start_urls = [
+        "http://webb.nmu.edu/Webb/ArchivedHTML/Education/state/syllabi.htm",
+        "http://webb.nmu.edu/Webb/ArchivedHTML/Education/state/outlines.htm"
+    ]
+
+    def start_requests(self):
+        for url in self.start_urls:
+            yield scrapy.Request(
+                url,
+                meta={
+                    'depth': 0,
+                    'hops_from_seed': 0,
+                    'source_url': url,
+                    'source_anchor': ''
+                },
+                callback=self.parse_for_files
+            )
+
+    def extract_links(self, response):
+        # The first `option` tag of each dropdown menu is a header, so skip it.
+        courses = response.css("select option:not(:first-child)")
+        for course in courses:
+            rel_url = course.css("option::attr(value)").extract_first()
+            url = response.urljoin(rel_url)
+            anchor = course.css("option::text").extract_first()
+            anchor = ' '.join(anchor.split())
+            yield (url, anchor)


### PR DESCRIPTION
http://webb.nmu.edu/Webb/ArchivedHTML/Education/state/syllabi.htm
http://webb.nmu.edu/Webb/ArchivedHTML/Education/state/outlines.htm

Very straightforward scraper, since the links to all the syllabi/course outlines are on the landing page.

There may be other archives of syllabi/course outlines from NMU that could be scraped similar to the ones at these two links, but what I have here is what I've found so far.