### PR TITLE
Fix scraper styling inconsistencies

### DIFF
--- a/osp_scraper/spiders/amherst.py
+++ b/osp_scraper/spiders/amherst.py
@@ -15,13 +15,13 @@ class AmherstSpider(CustomSpider):
         for term in terms:
             yield scrapy.FormRequest.from_response(
                 response,
-                formid='academics-schedule-search',
+                formid="academics-schedule-search",
                 formdata={
-                    'termid': term,
+                    'termid': term
                 },
                 meta={
                     'depth': 1,
-                    'hops_from_seed': 1,
+                    'hops_from_seed': 1
                 },
                 callback=self.parse_for_courses
             )

--- a/osp_scraper/spiders/asu.py
+++ b/osp_scraper/spiders/asu.py
@@ -13,7 +13,7 @@ class ASUSpider(CustomSpider):
         subjects = []
 
         start_url = "https://webapp4.asu.edu/catalog/"
-        subject_url = "https://webapp4.asu.edu/catalog/Subjects.html"
+        subjects_url = "https://webapp4.asu.edu/catalog/Subjects.html"
         search_url = "https://webapp4.asu.edu/catalog/classlist"
 
         def get_terms_codes(response):
@@ -34,20 +34,22 @@ class ASUSpider(CustomSpider):
                 for subject_code, subject_name in subjects:
                     yield scrapy.FormRequest(
                         search_url,
+                        method="GET",
                         formdata={
-                            "s": subject_code,
-                            "t": term_code,
-                            "e": "all",
-                            "hon": "F",
-                            "promod": "F",
+                            's': subject_code,
+                            't': term_code,
+                            'e': "all",
+                            'hon': "F",
+                            'promod': "F"
                         },
-                        method='GET',
-                        cookies={"onlineCampusSelection":"C"},
+                        cookies={
+                            'onlineCampusSelection': "C"
+                        },
                         meta={
-                            "depth": 1,
-                            "hops_from_seed": 1,
-                            "source_url": start_url,
-                            "source_anchor": subject_name + " " + term_name,
+                            'depth': 1,
+                            'hops_from_seed': 1,
+                            'source_url': start_url,
+                            'source_anchor': subject_name + " " + term_name
                         },
                         callback=self.parse_for_files
                     )
@@ -55,8 +57,8 @@ class ASUSpider(CustomSpider):
         yield scrapy.Request(start_url, callback=get_terms_codes, dont_filter=True)
 
     def extract_links(self, response):
-        for tag in response.css('a[title="Syllabus"]'):
-            url = tag.css('a::attr(href)').extract_first()
+        for tag in response.css("a[title='Syllabus']"):
+            url = tag.css("a::attr(href)").extract_first()
             if url:
-                anchor = tag.css('a::text').extract_first()
+                anchor = tag.css("a::text").extract_first()
                 yield (url, anchor)

--- a/osp_scraper/spiders/bcit.py
+++ b/osp_scraper/spiders/bcit.py
@@ -17,7 +17,7 @@ class BCITSpider(CustomSpider):
 
         for term in terms:
             meta = {
-                "term": term
+                'term': term
             }
             url = get_subjects_url.format(**meta)
             yield scrapy.Request(url, meta=meta, callback=self.parse_for_subjects)
@@ -28,7 +28,7 @@ class BCITSpider(CustomSpider):
 
         for subject in subjects:
             meta = dict(response.meta)
-            meta["subject"] = subject
+            meta['subject'] = subject
             url = get_courses_url.format(**meta)
             yield scrapy.Request(url, meta=meta, callback=self.parse_for_courses)
 
@@ -38,32 +38,32 @@ class BCITSpider(CustomSpider):
 
         for course in courses:
             meta = dict(response.meta)
-            meta["course"] = course
+            meta['course'] = course
             url = get_sections_url.format(**meta)
             yield scrapy.Request(url, meta=meta, callback=self.parse_for_sections)
 
     def parse_for_sections(self, response):
         get_outline_url = "http://www.bcit.ca/study/outlines/{course_id}"
-        rows = response.css('tr')
+        rows = response.css("tr")
         for row in rows:
-            course_id = row.css('a::attr(href)').extract_first()
+            course_id = row.css("a::attr(href)").extract_first()
             if course_id:
                 url = get_outline_url.format(course_id=course_id)
-                course_number = row.css('a::text').extract_first()
+                course_number = row.css("a::text").extract_first()
                 anchor = " ".join([
-                    response.meta["term"],
-                    response.meta["subject"],
-                    response.meta["course"],
+                    response.meta['term'],
+                    response.meta['subject'],
+                    response.meta['course'],
                     course_number
                 ]).strip()
 
                 yield scrapy.Request(
                     url,
                     meta={
-                        "depth": 0,
-                        "hops_from_seed": 1,
-                        "source_url": url,
-                        "source_anchor": anchor
+                        'depth': 4,
+                        'hops_from_seed': 4,
+                        'source_url': url,
+                        'source_anchor': anchor
                     },
                     callback=self.parse_for_files
                 )

--- a/osp_scraper/spiders/brandeis.py
+++ b/osp_scraper/spiders/brandeis.py
@@ -15,24 +15,24 @@ class BrandeisSpider(CustomSpider):
         start_url = "http://registrar-prod.unet.brandeis.edu/registrar/schedule/search/2017/Spring/1171/search"
 
         def get_terms(response):
-            terms = response.css('select[name="strm"] option')
+            terms = response.css("select[name='strm'] option")
             for term in terms:
-                code = term.css('option::attr(value)').extract_first()
-                anchor = term.css('option::text').extract_first()
+                code = term.css("option::attr(value)").extract_first()
+                anchor = term.css("option::text").extract_first()
                 # The anchor contains CRLF newlines, so clean it up.
-                anchor = ' '.join(anchor.split())
+                anchor = " ".join(anchor.split())
                 yield scrapy.FormRequest.from_response(
                     response,
+                    method="GET",
                     formdata={
-                        'strm': code,
+                        'strm': code
                     },
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': anchor,
+                        'source_anchor': anchor
                     },
-                    method='GET',
                     callback=get_pages
                 )
 
@@ -43,23 +43,24 @@ class BrandeisSpider(CustomSpider):
                 yield item
             # There's a row for page numbers on both the top and the bottom, so
             # just take the top one.
-            pages = response.css('div.paging')[0]
+            pages = response.css("div.paging")[0]
             # Last entry is a 'Next' symbol, so ignore it.
-            page_numbers = pages.css('a::text').extract()[:-1]
+            page_numbers = pages.css("a::text").extract()[:-1]
             for number in page_numbers:
+                anchor = response.meta['source_anchor'] + " " + number
                 yield scrapy.FormRequest.from_response(
                     response,
+                    method="GET",
                     formdata={
-                        'page': number,
+                        'page': number
                     },
                     meta={
                         'depth': response.meta['depth'] + 1,
                         'hops_from_seed': response.meta['hops_from_seed'] + 1,
                         'source_url': response.url,
                         # Use current page number as part of the anchor.
-                        'source_anchor': response.meta['source_anchor'] + ' ' + number,
+                        'source_anchor': anchor
                     },
-                    method='GET',
                     callback=self.parse_for_files
                 )
 
@@ -68,14 +69,15 @@ class BrandeisSpider(CustomSpider):
 
     def extract_links(self, response):
         # First row is the table header, so ignore it.
-        table_rows = response.css('table#classes-list tr')[1:]
+        table_rows = response.css("table#classes-list tr")[1:]
         for row in table_rows:
-            url = row.css('td:nth-child(2) a[target="_blank"]::attr(href)').extract_first()
+            url = row.css("td:nth-child(2) a[target='_blank']::attr(href)")\
+                .extract_first()
             # Some table rows don't contain links to syllabi, so check for that
             # possibility and skip this iteration if so.
             if not url:
                 continue
-            anchor = row.css('td:nth-child(2) a.def::text').extract_first()
+            anchor = row.css("td:nth-child(2) a.def::text").extract_first()
             # The anchor contains CRLF newlines (again), so clean it up.
-            anchor = ' '.join(anchor.split())
+            anchor = " ".join(anchor.split())
             yield (url, anchor)

--- a/osp_scraper/spiders/campusconcourse.py
+++ b/osp_scraper/spiders/campusconcourse.py
@@ -11,36 +11,36 @@ class CampusConcourseSpider(CustomSpider):
         for start_url in self.start_urls:
             yield scrapy.FormRequest(
                 start_url,
-                method='GET',
+                method="GET",
                 formdata={
-                    'search_performed': '1'
+                    'search_performed': "1"
                 },
                 callback=self.parse_for_page_numbers
             )
 
     def parse_for_page_numbers(self, response):
-        pages_text = response.css('.panel-footer label::text').extract_first()
+        pages_text = response.css(".panel-footer label::text").extract_first()
         num_pages = int(pages_text.split()[-1])
 
         for page in range(num_pages):
             yield scrapy.FormRequest(
                 response.url,
-                method='GET',
+                method="GET",
                 formdata={
-                    'search_performed': '1',
+                    'search_performed': "1",
                     'offset': str(page)
                 },
                 meta={
                     'depth': 1,
-                    'hops_from_seed': 1,
+                    'hops_from_seed': 1
                 },
                 callback=self.parse_for_courses
             )
 
     def parse_for_courses(self, response):
-        for row in response.css('#results_table tr'):
-            anchor = row.css('h4 a::text').extract_first()
-            relative_url = row.css('h4 a::attr(href)').extract_first()
+        for row in response.css("#results_table tr"):
+            anchor = row.css("h4 a::text").extract_first()
+            relative_url = row.css("h4 a::attr(href)").extract_first()
             url = response.urljoin(relative_url)
 
             yield scrapy.Request(

--- a/osp_scraper/spiders/cedarcrest.py
+++ b/osp_scraper/spiders/cedarcrest.py
@@ -12,21 +12,21 @@ class CedarCrestSpider(CustomSpider):
         start_url = "https://my.cedarcrest.edu/ics/staticpages/syllabilist.aspx"
 
         def get_terms(response):
-            terms = response.css('select#ddlTerm option')
+            terms = response.css("select#ddlTerm option")
             for term in terms:
-                value = term.css('option::attr(value)').extract_first()
-                anchor = term.css('option::text').extract_first()
+                value = term.css("option::attr(value)").extract_first()
+                anchor = term.css("option::text").extract_first()
                 yield scrapy.FormRequest.from_response(
                     response,
                     formdata={
                         'ddlTerm': value,
-                        'btnSubmit': 'Submit',
+                        'btnSubmit': "Submit"
                     },
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': anchor,
+                        'source_anchor': anchor
                     },
                     method='POST',
                     callback=self.parse_for_files
@@ -36,11 +36,11 @@ class CedarCrestSpider(CustomSpider):
 
     def extract_links(self, response):
         # Exclude the first result because it's a header.
-        table_rows = response.css('table#dgSyllabi tr')[1:]
+        table_rows = response.css("table#dgSyllabi tr")[1:]
         for row in table_rows:
-            url = row.css('td a::attr(href)').extract_first()
-            anchor = row.css('td a::text').extract_first()
+            url = row.css("td a::attr(href)").extract_first()
+            anchor = row.css("td a::text").extract_first()
             # The anchors can contain a lot of excess whitespace, so clean that
             # up a bit.
-            anchor = ' '.join(anchor.split())
+            anchor = " ".join(anchor.split())
             yield (url, anchor)

--- a/osp_scraper/spiders/clemson.py
+++ b/osp_scraper/spiders/clemson.py
@@ -14,44 +14,44 @@ class ClemsonSpider(CustomSpider):
         # Captcha is always the same (pseudo-captcha).
         yield scrapy.FormRequest(
             start_url,
+            method="POST",
             formdata={
-                'person_ck': 'CLEMSON',
-                'check_person': 'Logon',
+                'person_ck': "CLEMSON",
+                'check_person': "Logon",
             },
-            method='POST',
             callback=self.parse_for_search_terms
         )
 
     def parse_for_search_terms(self, response):
-        sem_codes = response.css('select[name="semester_selected"] option')\
-                            .css('::attr(value)')\
+        sem_codes = response.css("select[name='semester_selected'] option")\
+                            .css("::attr(value)")\
                             .extract()
         # Skip the first entry because it's an empty string.
-        disciplines = response.css('select[name="subj_selected"] option')[1:]
-        subj_codes = disciplines.css('option::attr(value)').extract()
+        disciplines = response.css("select[name='subj_selected'] option")[1:]
+        subj_codes = disciplines.css("option::attr(value)").extract()
         for sem_code, subj_code in itertools.product(sem_codes, subj_codes):
             # NOTE: from_response doesn't seem to work for some reason?
             yield scrapy.FormRequest(
                 response.url,
+                method="POST",
                 formdata={
                     'semester_selected': sem_code,
                     'subj_selected': subj_code,
-                    'search_course': 'Load+Course+Files'
+                    'search_course': "Load+Course+Files"
                 },
-                method='POST',
                 meta={
                     'depth': 1,
                     'hops_from_seed': 1,
                     'source_url': response.url,
-                    'source_anchor': sem_code + ' ' + subj_code,
+                    'source_anchor': sem_code + " " + subj_code,
                 },
                 callback=self.parse_for_files
             )
 
     def extract_links(self, response):
-        tags = response.css('tr td:nth-child(2) div a')
+        tags = response.css("tr td:nth-child(2) div a")
         for tag in tags:
-            url = tag.css('a::attr(href)').extract_first()
+            url = tag.css("a::attr(href)").extract_first()
             url = response.urljoin(url)
-            anchor = tag.css('a::text').extract_first()
+            anchor = tag.css("a::text").extract_first()
             yield (url, anchor)

--- a/osp_scraper/spiders/cmich.py
+++ b/osp_scraper/spiders/cmich.py
@@ -14,21 +14,21 @@ class CMichSpider(CustomSpider):
         yield scrapy.Request(
             start_url,
             headers={
-                "Accept" : "application/json"
+                'Accept' : "application/json"
             },
             meta={
                 'source_url': start_url,
                 'source_anchor': "",
                 'depth': 1,
-                'hops_from_seed': 1,
+                'hops_from_seed': 1
             },
             callback=self.parse_for_files
         )
 
     def extract_links(self, response):
         for course in json.loads(response.body):
-            crn = course.get("Crn")
-            anchor = course.get("CourseTitle")
+            crn = course.get('Crn')
+            anchor = course.get('CourseTitle')
             if crn and anchor:
                 url = "https://sbt.globalapp.cmich.edu/public/PublicSyllabusViewer.aspx?EPN=" + crn
-                yield (url, anchor) 
+                yield (url, anchor)

--- a/osp_scraper/spiders/gatech.py
+++ b/osp_scraper/spiders/gatech.py
@@ -12,7 +12,7 @@ class GATechSpider(CustomSpider):
         "http://www.econ.gatech.edu/courses",
         "http://www.lmc.gatech.edu/courses",
         "http://www.spp.gatech.edu/courses",
-        "http://www.modlangs.gatech.edu/courses",
+        "http://www.modlangs.gatech.edu/courses"
     ]
 
     def parse(self, response):
@@ -24,7 +24,7 @@ class GATechSpider(CustomSpider):
                 response.url,
                 method="POST",
                 formdata={
-                    "iacTermcode": code
+                    'iacTermcode': code
                 },
                 meta={
                     'source_url': response.url,
@@ -36,9 +36,9 @@ class GATechSpider(CustomSpider):
             )
 
     def extract_links(self, response):
-        for row in response.css('table tr'):
-            relative_url = row.css('td:last-child a::attr(href)').extract_first()
+        for row in response.css("table tr"):
+            relative_url = row.css("td:last-child a::attr(href)").extract_first()
             if relative_url:
                 url = response.urljoin(relative_url)
-                anchor = row.css('td:first-child::text').extract_first()
+                anchor = row.css("td:first-child::text").extract_first()
                 yield (url, anchor)

--- a/osp_scraper/spiders/hocking.py
+++ b/osp_scraper/spiders/hocking.py
@@ -13,23 +13,23 @@ class HockingSpider(CustomSpider):
 
         def get_term(response):
             # Skip the first entry since it has no value.
-            for term in response.css('select option')[1:]:
-                ddlTerm = term.css('option::attr(value)').extract_first()
-                anchor = term.css('option::text').extract_first()
+            for term in response.css("select option")[1:]:
+                term_code = term.css("option::attr(value)").extract_first()
+                anchor = term.css("option::text").extract_first()
                 # NOTE: from_response does not work, returns empty results page.
                 yield scrapy.FormRequest(
                     start_url,
+                    method="POST",
                     formdata={
-                        'ddlTerm': ddlTerm,
+                        'ddlTerm': term_code,
                         'txtSearch': "",
-                        'btnSubmit': "Search",
+                        'btnSubmit': "Search"
                     },
-                    method='POST',
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': anchor,
+                        'source_anchor': anchor
                     },
                     callback=self.parse_for_files
                 )
@@ -38,13 +38,13 @@ class HockingSpider(CustomSpider):
 
     def extract_links(self, response):
         # Skip the first row because it's the table header.
-        for row in response.css('table.styledTable tr')[1:]:
-            relative_url = row.css('a::attr(href)').extract_first()
+        for row in response.css("table.styledTable tr")[1:]:
+            relative_url = row.css("a::attr(href)").extract_first()
             url = response.urljoin(relative_url)
             # Text of each 'a' element is always "View/Save", so use previous
             # columns to construct the anchor.
-            term = row.css('td:first-child::text').extract_first()
-            course_title = row.css('td:nth-child(2)::text').extract_first()
-            course_number = row.css('td:nth-child(3)::text').extract_first()
-            anchor = ' '.join([term, course_title, course_number])
+            term = row.css("td:first-child::text").extract_first()
+            course_title = row.css("td:nth-child(2)::text").extract_first()
+            course_number = row.css("td:nth-child(3)::text").extract_first()
+            anchor = " ".join([term, course_title, course_number])
             yield (url, anchor)

--- a/osp_scraper/spiders/illinoisstate.py
+++ b/osp_scraper/spiders/illinoisstate.py
@@ -19,40 +19,40 @@ class IllinoisStateSpider(CustomSpider):
             years = response.css('#year option::attr(value)').extract()
             for dept, sem, year in itertools.product(depts, sems, years):
                 yield scrapy.FormRequest(
-                    'https://casit.illinoisstate.edu/syllabi/Database/QueryResults',
+                    "https://casit.illinoisstate.edu/syllabi/Database/QueryResults",
+                    method="POST",
                     formdata={
                         'Department': dept,
                         'semester': sem,
-                        'year': year,
+                        'year': year
                     },
-                    method='POST',
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': ' '.join([dept, sem, year]),
+                        'source_anchor': " ".join([dept, sem, year])
                     },
                     callback=self.parse_for_files
                 )
 
         def get_archive_searches(response):
-            depts = response.css('#deptNum option::attr(value)').extract()
-            sems = response.css('#semester option::attr(value)').extract()
-            years = response.css('#year option::attr(value)').extract()
+            depts = response.css("#deptNum option::attr(value)").extract()
+            sems = response.css("#semester option::attr(value)").extract()
+            years = response.css("#year option::attr(value)").extract()
             for dept, sem, year in itertools.product(depts, sems, years):
                 yield scrapy.FormRequest(
-                    'https://casit.illinoisstate.edu/syllabi/Archive/QueryResults',
+                    "https://casit.illinoisstate.edu/syllabi/Archive/QueryResults",
+                    method="GET",
                     formdata={
                         'deptNum': dept,
                         'semester': sem,
-                        'year': year,
+                        'year': year
                     },
-                    method='GET',
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': ' '.join([dept, sem, year]),
+                        'source_anchor': " ".join([dept, sem, year])
                     },
                     callback=self.parse_for_files
                 )
@@ -61,10 +61,10 @@ class IllinoisStateSpider(CustomSpider):
         yield scrapy.Request(archive_url, callback=get_archive_searches)
 
     def extract_links(self, response):
-        table_rows = response.css('table#syllabusList tbody tr')
+        table_rows = response.css("table#syllabusList tbody tr")
         for row in table_rows:
-            url = row.css('tr td:last-child a::attr(href)').extract_first()
-            class_num = row.css('tr td:nth-child(3)::text').extract_first()
-            section = row.css('tr td:nth-child(4)::text').extract_first()
-            anchor = class_num.strip() + ' ' + section
+            url = row.css("tr td:last-child a::attr(href)").extract_first()
+            class_num = row.css("tr td:nth-child(3)::text").extract_first()
+            section = row.css("tr td:nth-child(4)::text").extract_first()
+            anchor = class_num.strip() + " " + section
             yield (url, anchor)

--- a/osp_scraper/spiders/mhc.py
+++ b/osp_scraper/spiders/mhc.py
@@ -21,26 +21,26 @@ class MHCSpider(CustomSpider):
                 anchor = entry['CourseCode']
                 yield scrapy.FormRequest(
                     api_url,
+                    method="GET",
                     formdata={
                         'outlineId': str(num),
                     },
                     meta={
-                        'source_url': response.url,
-                        'source_anchor': anchor,
                         'depth': 1,
                         'hops_from_seed': 1,
+                        'source_url': response.url,
+                        'source_anchor': anchor
                     },
-                    method='GET',
                     callback=self.parse_for_files
                 )
 
         yield scrapy.FormRequest(
             api_url,
+            method="GET",
             formdata={
-                'start': '1',
+                'start': "1",
                 # Set limit to -1 to signify no limit and pull all courses.
-                'limit': '-1',
+                'limit': "-1",
             },
-            method='GET',
             callback=get_pdfs
         )

--- a/osp_scraper/spiders/nmu.py
+++ b/osp_scraper/spiders/nmu.py
@@ -20,7 +20,7 @@ class NMUSpider(CustomSpider):
                     'depth': 0,
                     'hops_from_seed': 0,
                     'source_url': url,
-                    'source_anchor': ''
+                    'source_anchor': ""
                 },
                 callback=self.parse_for_files
             )

--- a/osp_scraper/spiders/oru.py
+++ b/osp_scraper/spiders/oru.py
@@ -16,10 +16,10 @@ class ORUSpider(CustomSpider):
                 name = option.css("option::text").extract_first()
                 yield scrapy.FormRequest(
                     response.url,
+                    method="GET",
                     formdata={
                         'term': code
                     },
-                    method="GET",
                     meta={
                         'source_anchor': name
                     },

--- a/osp_scraper/spiders/palmbeachstate.py
+++ b/osp_scraper/spiders/palmbeachstate.py
@@ -5,14 +5,14 @@ import scrapy
 from ..spiders.CustomSpider import CustomSpider
 
 class PalmBeachStateSpider(CustomSpider):
-    name = 'palmbeachstate'
+    name = "palmbeachstate"
 
     start_urls = ["http://www.palmbeachstate.edu/pf/"]
 
     def parse(self, response):
         yield scrapy.FormRequest.from_response(
             response,
-            formid='form1',
+            formid="form1",
             formdata={
                 'ctl00$ContentPlaceHolder1$btnPeopleSearch': "Search"
             },

--- a/osp_scraper/spiders/pdf.py
+++ b/osp_scraper/spiders/pdf.py
@@ -26,13 +26,13 @@ class PDFSpider(CustomSpider):
         for page_num in range(pgs):
             page = pdf.getPage(page_num)
 
-            annotations = page.get("/Annots", [])
+            annotations = page.get('/Annots', [])
             for annotation in annotations:
                 annot_object = annotation.getObject()
 
-                a_tag = annot_object.get("/A")
-                if a_tag and "/URI" in a_tag:
-                    uri = a_tag["/URI"]
+                a_tag = annot_object.get('/A')
+                if a_tag and '/URI' in a_tag:
+                    uri = a_tag['/URI']
                     if isinstance(uri, pyPdf.generic.ByteStringObject):
                         uri = uri.decode("utf-8").replace("\x00", "")
                     yield (uri, uri)

--- a/osp_scraper/spiders/psu.py
+++ b/osp_scraper/spiders/psu.py
@@ -13,19 +13,19 @@ class PSUSpider(CustomSpider):
     def parse(self, response):
         view1_url = "http://www.altoona.psu.edu/syllabi/view1.php"
 
-        course_abbreviations = response.css("#course_abbr option::text").extract()
-        for course in course_abbreviations:
+        courses = response.css("#course_abbr option::text").extract()
+        for course in courses:
             yield scrapy.FormRequest(
                 view1_url,
                 formdata={
-                    "course_abbr": course,
+                    'course_abbr': course,
                 },
-                method='POST',
+                method="POST",
                 meta={
-                    "depth": 1,
-                    "hops_from_seed": 1,
-                    "source_url": response.url,
-                    "source_anchor": "",
+                    'depth': 1,
+                    'hops_from_seed': 1,
+                    'source_url': response.url,
+                    'source_anchor': "",
                 },
                 callback=self.get_semester_urls
             )
@@ -39,10 +39,10 @@ class PSUSpider(CustomSpider):
             yield scrapy.Request(
                 url,
                 meta={
-                    'source_url': response.url,
-                    'source_anchor': anchor,
                     'depth': response.meta['depth'] + 1,
                     'hops_from_seed': response.meta['hops_from_seed'] + 1,
+                    'source_url': response.url,
+                    'source_anchor': anchor
                 },
                 callback=self.parse_for_files
             )

--- a/osp_scraper/spiders/sfasu.py
+++ b/osp_scraper/spiders/sfasu.py
@@ -31,10 +31,10 @@ class SFASUSpider(CustomSpider):
                         'ctl00$ContentPlaceHolder1$termreport1$DropDownListTerm': code
                     },
                     meta={
-                        'source_url': response.url,
-                        'source_anchor': name,
                         'depth': 1,
-                        'hops_from_seed': 1
+                        'hops_from_seed': 1,
+                        'source_url': response.url,
+                        'source_anchor': name
                     },
                     callback=self.parse_for_files
                 )

--- a/osp_scraper/spiders/sfu.py
+++ b/osp_scraper/spiders/sfu.py
@@ -43,7 +43,7 @@ class SFUSpider(CustomSpider):
 
     def parse_for_sections(self, response):
         # Get the url parameter values from the request url
-        url_params = re.sub(r"[^&]*=", "", response.url).split('&')
+        url_params = re.sub(r"[^&]*=", "", response.url).split("&")
         base_url_format = "http://www.sfu.ca/outlines.html?{0}/{1}/{2}/{3}"
         base_url = base_url_format.format(*url_params)
 
@@ -52,10 +52,10 @@ class SFUSpider(CustomSpider):
             yield scrapy.Request(
                 url,
                 meta={
-                    "depth": 1,
-                    "hops_from_seed": 1,
-                    "source_url": self.start_urls[0],
-                    "source_anchor": response.meta["anchor"]
+                    'depth': 1,
+                    'hops_from_seed': 1,
+                    'source_url': self.start_urls[0],
+                    'source_anchor': response.meta['anchor']
                 },
                 callback=self.parse_for_files
             )

--- a/osp_scraper/spiders/sheridanc.py
+++ b/osp_scraper/spiders/sheridanc.py
@@ -12,7 +12,7 @@ class SheridanSpider(CustomSpider):
     start_urls = ["https://ulysses.sheridanc.on.ca/coutline/results.jsp"]
 
     def parse(self, response):
-        current_year = int(response.headers["Date"].split()[3])
+        current_year = int(response.headers['Date'].split()[3])
         years = range(2000, current_year + 2)
         seasons = response.css("#season option::attr(value)").extract()
         programs = response.css("#program_ps option::attr(value)").extract()

--- a/osp_scraper/spiders/shsu.py
+++ b/osp_scraper/spiders/shsu.py
@@ -10,27 +10,27 @@ class SHSUSpider(CustomSpider):
     allowed_domains = ["shsu.edu"]
 
     def start_requests(self):
-        start_url = 'https://ww2.shsu.edu/faci10wp/'
+        start_url = "https://ww2.shsu.edu/faci10wp/"
 
         def get_terms(response):
-            years = response.css('select[name="year"] option::attr(value)')
-            semesters = response.css('select[name="semester"] option::attr(value)')
+            years = response.css("select[name='year'] option::attr(value)")
+            semesters = response.css("select[name='semester'] option::attr(value)")
             searches = itertools.product(years.extract(), semesters.extract())
             for year, semester in searches:
                 yield scrapy.FormRequest(
                     response.urljoin('display.php'),
+                    method="POST",
                     formdata={
                         'semester': semester,
                         'year': year,
                         # '-' means search all departments.
-                        'dept': '-',
+                        'dept': "-",
                     },
-                    method='POST',
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': year + ' ' + semester,
+                        'source_anchor': year + " " + semester,
                     },
                     callback=self.parse_for_files
                 )
@@ -38,17 +38,17 @@ class SHSUSpider(CustomSpider):
         yield scrapy.Request(start_url, callback=get_terms)
 
     def extract_links(self, response):
-        tags_root = response.css('tr.noshade td:nth-child(2)')
+        tags_root = response.css("tr.noshade td:nth-child(2)")
         # Each cell contains multiple course sections that need to be selected.
-        syllabus_links = tags_root.css('font ~ span')
-        class_numbers = tags_root.css('font')
+        syllabus_links = tags_root.css("font ~ span")
+        class_numbers = tags_root.css("font")
         for syllabus, number in zip(syllabus_links, class_numbers):
-            link = syllabus.css('a::attr(href)').extract_first()
+            link = syllabus.css("a::attr(href)").extract_first()
             # Skip iteration if the course doesn't have a syllabus link.
             if not link:
                 continue
             url = response.urljoin(link)
-            number_text = number.css('font::text').extract_first()
+            number_text = number.css("font::text").extract_first()
             # The anchor contains lots of CRLF line endings, so clean it up.
-            anchor = ' '.join(number_text.split())
+            anchor = " ".join(number_text.split())
             yield (url, anchor)

--- a/osp_scraper/spiders/tamiu.py
+++ b/osp_scraper/spiders/tamiu.py
@@ -10,16 +10,16 @@ class TAMIUSpider(CustomSpider):
     start_urls = ["https://info.tamiu.edu/courseslist.aspx"]
 
     def parse(self, response):
-        terms = response.css('#ctl00_ContentPlaceHolderMaster_ddlTerms option')
+        terms = response.css("#ctl00_ContentPlaceHolderMaster_ddlTerms option")
         for term in terms:
-            value = term.css('option::attr(value)').extract_first()
-            anchor = term.css('option::text').extract_first()
+            value = term.css("option::attr(value)").extract_first()
+            anchor = term.css("option::text").extract_first()
             yield scrapy.FormRequest.from_response(
                 response,
+                method="POST",
                 formdata={
                     'ctl00$ContentPlaceHolderMaster$ddlTerms': value
                 },
-                method='POST',
                 meta={
                     'depth': 1,
                     'hops_from_seed': 1,
@@ -31,16 +31,16 @@ class TAMIUSpider(CustomSpider):
             )
 
     def extract_links(self, response):
-        rows = response.css('div#page-wrap tbody tr')
+        rows = response.css("div#page-wrap tbody tr")
         for row in rows:
-            courseID = row.css('td:nth-child(2)::text').extract_first()
-            course_section = row.css('td:first-child::text').extract_first()
+            course_id = row.css("td:nth-child(2)::text").extract_first()
+            course_section = row.css("td:first-child::text").extract_first()
             # course_sections look like 'COMM 1315.W01'. The part that comes
             # after the period is what's necessary for the syllabus url.
-            sectionID = course_section.split('.')[-1]
+            section_id = course_section.split('.')[-1]
             relative_url_format = "viewfile.aspx?termID={0}&courseID={1}&sectionID={2}"
             relative_url = relative_url_format.format(
-                    response.meta['termID'], courseID, sectionID)
+                response.meta['termID'], course_id, section_id)
             url = response.urljoin(relative_url)
-            anchor = course_section + ' ' + courseID
+            anchor = course_section + " " + course_id
             yield (url, anchor)

--- a/osp_scraper/spiders/tccd.py
+++ b/osp_scraper/spiders/tccd.py
@@ -21,20 +21,21 @@ class TCCDSpider(CustomSpider):
             anchor = tag.css("a::text").extract_first()
 
             yield scrapy.Request(
-                url, 
+                url,
                 meta={
                     "depth": 1,
                     "hops_from_seed": 1,
                     "source_url": response.url,
-                    "source_anchor": anchor,
+                    "source_anchor": anchor
                 },
                 callback=self.parse_for_files
             )
 
     def extract_links(self, response):
-        syllabus_link_tag = response.css('tr:last-child td.info a')
-        syllabus_relative_url = syllabus_link_tag.css('a::attr(href)').re_first("displayLink[^']*")
+        syllabus_link_tag = response.css("tr:last-child td.info a")
+        syllabus_relative_url = syllabus_link_tag.css("a::attr(href)")\
+            .re_first("displayLink[^']*")
         url = response.urljoin(syllabus_relative_url)
-        anchor = syllabus_link_tag.css('a::text').extract_first()
+        anchor = syllabus_link_tag.css("a::text").extract_first()
 
         yield (url, anchor)

--- a/osp_scraper/spiders/temple.py
+++ b/osp_scraper/spiders/temple.py
@@ -9,33 +9,43 @@ class TempleSpider(CustomSpider):
     allowed_domains = ["temple.edu"]
 
     def start_requests(self):
-        terms = []
-        subjects = []
-
         get_syllabi_url = "https://math.temple.edu/cgi-bin/get_syllabi"
 
         def get_years(response):
             years = response.css("#year option::attr(value)").extract()[1:]
 
             for year in years:
-                yield scrapy.Request(response.url+"?year="+year, callback=get_semesters)
+                yield scrapy.Request(
+                    response.url + "?year=" + year,
+                    callback=get_semesters
+                )
 
         def get_semesters(response):
-            semesters = response.css("#semester option::attr(value)").extract()[1:]
+            semesters = response.css("#semester option::attr(value)")\
+                .extract()[1:]
 
             for semester in semesters:
-                yield scrapy.Request(response.url+"&semester="+semester, callback=get_courses)
+                yield scrapy.Request(
+                    response.url + "&semester=" + semester,
+                    callback=get_courses
+                )
 
         def get_courses(response):
             courses = response.css("#course option::attr(value)").extract()[1:]
 
             for course in courses:
-                yield scrapy.Request(response.url+"&course="+course, callback=get_sections)
+                yield scrapy.Request(
+                    response.url + "&course=" + course,
+                    callback=get_sections
+                )
 
         def get_sections(response):
             sections = response.css("#section option::attr(value)").extract()[1:]
 
             for section in sections:
-                yield scrapy.Request(response.url+"&section="+section, callback=self.parse_for_files)
+                yield scrapy.Request(
+                    response.url + "&section=" + section,
+                    callback=self.parse_for_files
+                )
 
         yield scrapy.Request(get_syllabi_url, callback=get_years)

--- a/osp_scraper/spiders/tjc.py
+++ b/osp_scraper/spiders/tjc.py
@@ -14,11 +14,11 @@ class TJCSpider(CustomSpider):
             term_value = option.css("option::attr(value)").extract_first()
             yield scrapy.FormRequest(
                 response.url,
+                method="POST",
                 formdata={
                     'pi_term_code': term_value,
                     'pi_subj': ""
                 },
-                method='POST',
                 callback=self.parse_for_courses
             )
 

--- a/osp_scraper/spiders/tru.py
+++ b/osp_scraper/spiders/tru.py
@@ -15,7 +15,7 @@ class TRUSpider(CustomSpider):
         tabs = response.css("ul.tabs li a")
         for tab in tabs:
             url = tab.css("::attr(href)").extract_first()
-            anchor = ' '.join(tab.css("::text").extract_first().split())
+            anchor = " ".join(tab.css("::text").extract_first().split())
             yield scrapy.Request(
                 response.urljoin(url),
                 meta={
@@ -34,5 +34,5 @@ class TRUSpider(CustomSpider):
             url = onclick.split("'")[1]
             course_num = row.css("td:first-child strong::text").extract_first()
             course_name = row.css("td:nth-child(2)::text").extract_first()
-            anchor = course_num + ' ' + course_name
+            anchor = course_num + " " + course_name
             yield (url, anchor)

--- a/osp_scraper/spiders/umuc.py
+++ b/osp_scraper/spiders/umuc.py
@@ -11,7 +11,7 @@ class UMUCSpider(CustomSpider):
     start_urls = [
         "http://webapps.umuc.edu/soc/asia.cfm?fAcad=UGRD",
         "http://webapps.umuc.edu/soc/asia.cfm?fAcad=GR4T",
-        "http://webapps.umuc.edu/soc/asia.cfm?fAcad=UBSU",
+        "http://webapps.umuc.edu/soc/asia.cfm?fAcad=UBSU"
     ]
 
     def parse(self, response):
@@ -28,16 +28,16 @@ class UMUCSpider(CustomSpider):
                     yield scrapy.FormRequest(
                         response.url,
                         formdata={
-                            "fSess": session_value,
-                            "fLoc": location,
-                            "fFetchRows": "99999",
+                            'fSess': session_value,
+                            'fLoc': location,
+                            'fFetchRows': "99999",
                         },
-                        method='GET',
+                        method="GET",
                         meta={
-                            "depth": 1,
-                            "hops_from_seed": 1,
-                            "source_url": response.url,
-                            "source_anchor": session_text,
+                            'depth': 1,
+                            'hops_from_seed': 1,
+                            'source_url': response.url,
+                            'source_anchor': session_text
                         },
                         callback=self.parse_for_syllabi
                     )
@@ -59,12 +59,12 @@ class UMUCSpider(CustomSpider):
                 )
 
     def submit_form(self, response):
-        url = response.css('form::attr(action)').extract_first()
-        method = response.css('form::attr(method)').extract_first() or "GET"
+        url = response.css("form::attr(action)").extract_first()
+        method = response.css("form::attr(method)").extract_first() or "GET"
         formdata = {}
-        for field in response.css('form input[type=hidden]'):
-            name = field.css('input::attr(name)').extract_first()
-            value = field.css('input::attr(value)').extract_first()
+        for field in response.css("form input[type=hidden]"):
+            name = field.css("input::attr(name)").extract_first()
+            value = field.css("input::attr(value)").extract_first()
             if name and value:
                 formdata[name] = value
 

--- a/osp_scraper/spiders/utrgv.py
+++ b/osp_scraper/spiders/utrgv.py
@@ -39,10 +39,10 @@ class UTRGVSpider(CustomSpider):
             yield scrapy.Request(
                 url,
                 meta={
-                    'source_url': response.url,
-                    'source_anchor': response.meta['source_anchor'],
                     'depth': response.meta['depth'] + 1,
-                    'hops_from_seed': response.meta['hops_from_seed'] + 1
+                    'hops_from_seed': response.meta['hops_from_seed'] + 1,
+                    'source_url': response.url,
+                    'source_anchor': response.meta['source_anchor']
                 },
                 callback=self.parse_results_page
             )

--- a/osp_scraper/spiders/westernseminary.py
+++ b/osp_scraper/spiders/westernseminary.py
@@ -18,13 +18,14 @@ class WesternSeminarySpider(CustomSpider):
                 semesters = campuses[cid]["semesters"]
                 for semester in semesters:
                     url = search_url.format(cid, semester.replace(" ", "+"))
+                    anchor = campuses[cid]["name"] + " " + semester
                     yield scrapy.Request(
                         url,
                         meta={
                             "depth": 1,
                             "hops_from_seed": 1,
                             "source_url": response.url,
-                            "source_anchor": campuses[cid]["name"] + " " + semester
+                            "source_anchor": anchor
                         },
                         callback=self.parse_for_files
                     )
@@ -34,6 +35,6 @@ class WesternSeminarySpider(CustomSpider):
     def extract_links(self, response):
         results = json.loads(response.body)
         for result in results:
-            url = result["url"]
-            name = result["crsname"]
+            url = result['url']
+            name = result['crsname']
             yield (url, name)

--- a/osp_scraper/spiders/woodbury.py
+++ b/osp_scraper/spiders/woodbury.py
@@ -13,32 +13,32 @@ class WoodburySpider(CustomSpider):
         start_url = "https://go.woodbury.edu/syllabus/view.aspx"
 
         def get_years(response):
-            years = response.css('select#dYear option::attr(value)').extract()
-            terms = response.css('select#dTerm option::attr(value)').extract()
+            years = response.css("select#dYear option::attr(value)").extract()
+            terms = response.css("select#dTerm option::attr(value)").extract()
             for year, term in itertools.product(years, terms):
                 yield scrapy.FormRequest.from_response(
                     response,
+                    method="POST",
                     formdata={
                         'dYear': year,
                         'dTerm': term,
-                        'bRefresh': 'Show+Syllabus',
+                        'bRefresh': "Show+Syllabus"
                     },
                     meta={
                         'depth': 1,
                         'hops_from_seed': 1,
                         'source_url': response.url,
-                        'source_anchor': year + ' ' + term,
+                        'source_anchor': year + ' ' + term
                     },
-                    method='POST',
                     callback=self.parse_for_files
                 )
 
         yield scrapy.Request(start_url, callback=get_years)
 
     def extract_links(self, response):
-        tags = response.css('#lCourses a')
+        tags = response.css("#lCourses a")
         for tag in tags:
-            url = tag.css('a::attr(href)').extract_first()
+            url = tag.css("a::attr(href)").extract_first()
             url = response.urljoin(url)
-            anchor = tag.css('a::text').extract_first()
+            anchor = tag.css("a::text").extract_first()
             yield (url, anchor)


### PR DESCRIPTION
This PR fixes some inconsistencies in many of the scrapers, such as quotation usage, line length, trailing commas, and parameter order. 