### PR TITLE
Tweaks for EDU Repo crawler

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -35,10 +35,7 @@ def main(csv_file, local, institution):
             if not institution or institution == row['id']:
                 # run custom scraper, but only if not running locally
                 if not local and 'Custom Scraper Name' in row:
-                    params = {
-                        "start_urls": extract_urls(row['Database URLs'])
-                    }
-                    crawl_func(row['Custom Scraper Name'], **params)
+                    crawl_func(row['Custom Scraper Name'])
 
                 # find comma-separated URLs in these columns
                 urls = extract_urls(row['Doc URLs'])

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -1,12 +1,7 @@
 #!/usr/bin/env python3
 
-import sys
-import os.path
 import csv
 import logging
-import itertools
-import urllib.parse
-import re
 
 import click
 
@@ -15,13 +10,11 @@ from osp_scraper.tasks import make_params, crawl
 
 log = logging.getLogger('edu_repo_crawler')
 
-
 def extract_urls(s):
-    """return a list of clean URLs from a comma-separated string"""
+    """Return a list of clean URLs from a comma-separated string."""
     urls = (u.strip() for u in s.split(','))
     urls = (u for u in urls if u.startswith('http'))
     return list(urls)
-
 
 @click.command()
 @click.argument('csv_file', type=click.Path(exists=True))
@@ -33,13 +26,14 @@ def main(csv_file, local, institution):
     with open(csv_file) as f:
         for row in csv.DictReader(f):
             if not institution or institution == row['id']:
-                # run custom scraper, but only if not running locally
+                # Run custom scraper, but only if not running locally.
                 if not local and 'Custom Scraper Name' in row:
                     crawl_func(row['Custom Scraper Name'])
 
-                # find comma-separated URLs in these columns
+                # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])
                 urls.extend(extract_urls(row['Mixed URLs']))
+                # NOTE: Should database URLs be included?
                 urls.extend(extract_urls(row['Database URLs']))
 
                 if urls:

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -47,7 +47,7 @@ def main(csv_file, local, institution):
                     params = make_params(urls)
                     log.debug("Parameters: %r", params)
 
-                    if row['robots.txt'].lower() == "ignore":
+                    if row['robots.txt'].strip().lower() == "ignore":
                         params['ignore_robots_txt'] = True
                         log.info("Ignoring robots.txt")
 

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -28,7 +28,13 @@ def main(csv_file, local, institution):
             if not institution or institution == row['id']:
                 # Run custom scraper, but only if not running locally.
                 if not local and 'Custom Scraper Name' in row:
-                    crawl_func(row['Custom Scraper Name'])
+                    # Create a parameter of database URLs that can be used by
+                    # custom scrapers as needed.
+                    params = {
+                        "database_urls": extract_urls(row['Database URLs'])
+                    }
+                    crawl_func(row['Custom Scraper Name'], **params)
+                    break
 
                 # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -33,7 +33,6 @@ def main(csv_file, local, institution):
                 # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])
                 urls.extend(extract_urls(row['Mixed URLs']))
-                # NOTE: Should database URLs be included?
                 urls.extend(extract_urls(row['Database URLs']))
 
                 if urls:

--- a/osp_scraper/spiders/campusconcourse.py
+++ b/osp_scraper/spiders/campusconcourse.py
@@ -8,7 +8,7 @@ class CampusConcourseSpider(CustomSpider):
     name = 'campusconcourse'
 
     def start_requests(self):
-        for start_url in self.start_urls:
+        for start_url in self.database_urls:
             yield scrapy.FormRequest(
                 start_url,
                 method="GET",

--- a/osp_scraper/spiders/campusconcourse_with_files.py
+++ b/osp_scraper/spiders/campusconcourse_with_files.py
@@ -8,7 +8,7 @@ class CampusConcourseWithFilesSpider(CustomSpider):
     name = "campusconcourse_with_files"
 
     def start_requests(self):
-        for start_url in self.start_urls:
+        for start_url in self.database_urls:
             yield scrapy.FormRequest(
                 start_url,
                 formdata={


### PR DESCRIPTION
General cleanup and improvements for `edu_repo_crawler.py`.  The two biggest things are the first two commits:

1) Since `start_urls` is defined in each custom scraper class, we shouldn't be trying to set the `start_urls` based on a cell spreadsheet.
2) Since the '1st Search Result Page' can contain URLs as well, include that as part of the URL collection.

Also, as I `NOTE` in an inline comment, should 'Database URLs' really be part of the big crawl?  'Database URLs' often contain URLs that will have very permissive prefixes (e.g., `https://www.kingsu.ca/academics/bachelor-programs`), and therefore will be likely to seed very long and broad crawls.