### PR TITLE
Fixup PDF scraper

### DIFF
--- a/osp_scraper/spiders/pdf.py
+++ b/osp_scraper/spiders/pdf.py
@@ -25,12 +25,8 @@ class PDFSpider(CustomSpider):
                     'source_url': start_url,
                     'source_anchor': start_url
                 },
-                callback=self.parse
+                callback=self.parse_for_files
             )
-
-    def parse(self, response):
-        for item in self.parse_for_files(response):
-            yield item
 
     def extract_links(self, response):
         pdf = pyPdf.PdfFileReader(BytesIO(response.body))

--- a/osp_scraper/spiders/pdf.py
+++ b/osp_scraper/spiders/pdf.py
@@ -3,6 +3,7 @@
 from io import BytesIO
 
 import PyPDF2 as pyPdf
+import scrapy
 
 from ..spiders.CustomSpider import CustomSpider
 
@@ -12,8 +13,20 @@ class PDFSpider(CustomSpider):
     every single link from the PDF and yield a PageItem for each PDF, with the
     links as file_urls.
     """
-
     name = "pdf"
+
+    def start_requests(self):
+        for start_url in self.database_urls:
+            yield scrapy.Request(
+                start_url,
+                meta={
+                    'depth': 0,
+                    'hops_from_seed': 0,
+                    'source_url': start_url,
+                    'source_anchor': start_url
+                },
+                callback=self.parse
+            )
 
     def parse(self, response):
         for item in self.parse_for_files(response):


### PR DESCRIPTION
Changing the PDF scraper to use `database_urls` is required per 0fe7ca1.  In addition, there were latent issues with the PDF scraper not setting meta parameters.