### PR TITLE
edurepocrawler: Check for 'Custom Scraper Name' properly

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -27,7 +27,7 @@ def main(csv_file, local, institution):
         for row in csv.DictReader(f):
             if not institution or institution == row['id']:
                 # Run custom scraper, but only if not running locally.
-                if not local and 'Custom Scraper Name' in row:
+                if not local and row['Custom Scraper Name']:
                     # Create a parameter of database URLs that can be used by
                     # custom scrapers as needed.
                     params = {


### PR DESCRIPTION
The rows extracted by `csv.DictReader` are populated such that `'Custom Scraper Name' in row` will return true for every row that has a 'Custom Scraper Name' cell (i.e., every row), even if it's empty. This caused errors when trying to run the `crawl_func` for each custom scraper.

Sidenote: Is there a reason for the `not local` part of the `if` statement?  Why wouldn't you want to run custom scrapers while running locally?