### PR TITLE
Follow frame/iframe src URLs as links in FilterSpider

### DIFF
--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -134,6 +134,15 @@ class FilterSpider(BaseSpider):
 
             yield (url, anchor)
 
+        for frame in (response.css("frame") + response.css("iframe")):
+            relative_url = frame.css("::attr(src)").extract_first()
+            url = response.urljoin(relative_url)
+
+            if url.startswith("http"):
+                anchor = frame.css("::attr(name)").extract_first()
+
+                yield (url, anchor)
+
 
     def process_file_url(self, response, url, anchor):
         """return `Request.meta` for a file url, or None to skip"""


### PR DESCRIPTION
I thought this seemed reasonable, as frames/iframes in HTML are as valuable or more valuable to follow than `a` tag links.  There are a few sites that we've found that weren't getting scraped properly because links were embedded in frames.  On an individual basis, we can change the URL to that of the frame, but this should fix it more generally and shouldn't have any significant downsides.  @wearpants Thoughts?