### PR TITLE
Add script to run osp_scraper_spider on a single URL

### DIFF
--- a/bin/osp_scraper_spider.py
+++ b/bin/osp_scraper_spider.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import logging
+
+import click
+
+from osp_scraper.tasks import make_params, crawl
+
+log = logging.getLogger('edu_repo_crawler')
+
+@click.command()
+@click.argument('url')
+def main(url):
+    params = make_params([url])
+    log.debug("Parameters: %r", params)
+
+    crawl('osp_scraper_spider', **params)
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()


### PR DESCRIPTION
This is a really simple script that lets you run `osp_scraper_spider` on a single URL. It's useful for testing to see how the scraper handles a single URL in the spreadsheet.