### PR TITLE
requirements.txt: Update Scrapy and related packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipython==5.1.0
 PyDispatcher==2.0.5
-Scrapy==1.1.0
+Scrapy==1.4.0
 Twisted==16.2.0
 attrs==16.0.0
 botocore==1.4.33
@@ -11,7 +11,7 @@ docutils==0.12
 idna==2.1
 jmespath==0.9.0
 lxml==3.6.0
-parsel==1.0.2
+parsel==1.2.0
 pyOpenSSL==16.0.0
 pyasn1==0.1.9
 pyasn1-modules==0.0.8
@@ -21,7 +21,7 @@ python-dateutil==2.5.3
 queuelib==1.4.2
 service-identity==16.0.0
 six==1.10.0
-w3lib==1.14.2
+w3lib==1.17.0
 zope.interface==4.2.0
 celery==3.1.23
 pytz==2016.6.1


### PR DESCRIPTION
The version of Scrapy being used is quite old and should probably be updated.  For reference, here are the changelogs:

[Scrapy changelog](https://scrapy.readthedocs.io/en/latest/news.html#scrapy-1-4-0-2017-05-18)
[parsel changelog](https://parsel.readthedocs.io/en/latest/history.html#history)
[w3lib changelog](https://w3lib.readthedocs.io/en/latest/#changelog)

As best I can tell, nothing that's changed in any of these packages is backwards incompatible in a way that would affect the scrapers, and I've done some (lite) testing that confirms this.  On the contrary, there are several new features we could benefit from, including [a recent convenient addition by](https://github.com/scrapy/scrapy/pull/2721) @HarrisonGregg.

This might also be the time to consider upgrading `osp-scraper`'s other dependencies, but I've left that investigation out of this PR for now.