### PR TITLE
Add 'rtf' to ALLOWED_FILE_TYPES

### DIFF
--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -13,7 +13,7 @@ from .. import version
 from ..filterware import Filter
 
 # file types we download
-ALLOWED_FILE_TYPES = frozenset({'pdf', 'doc', 'docx'})
+ALLOWED_FILE_TYPES = frozenset({'pdf', 'doc', 'docx', 'rtf'})
 
 class BaseSpider(scrapy.spiders.Spider):
     """Common base class for all syllascrape spiders"""


### PR DESCRIPTION
With the addition of [pipeline support for RTF files](https://github.com/opensyllabus/osp-pipeline/pull/34), we should be allowing RTF file types here as well.