### PR TITLE
edu_repo_crawler: Don't `break` after starting custom scraper crawl

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -34,7 +34,6 @@ def main(csv_file, local, institution):
                         "database_urls": extract_urls(row['Database URLs'])
                     }
                     crawl_func(row['Custom Scraper Name'], **params)
-                    break
 
                 # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])


### PR DESCRIPTION
Rows that contain custom scraper names shouldn't prevent general scraper crawls on those rows.