### PR TITLE
talis: Don't collect RIS files

### DIFF
--- a/osp_scraper/spiders/talis.py
+++ b/osp_scraper/spiders/talis.py
@@ -49,8 +49,3 @@ class TalisSpider(CustomSpider):
                 },
                 callback=self.parse_for_courses
             )
-
-    def extract_links(self, response):
-        title = response.css("#pageTitle::text").get()
-        url = response.css("#exportsToRIS::attr(href)").get()
-        yield (url, title)


### PR DESCRIPTION
The RIS and HTML sources are similar enough that they could be hard to
de-duplicate.  In addition, while we could theoretically benefit from
the nicely structured format of the RIS files, we don't currently have
any system in place to benefit from that structure, and mixing
structured and unstructured data adds complexity.  For now, stick with
just HTML.

Based on some recent group discussions.