### PR TITLE
Rename `BaseSpider` to `OSPSpider`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ All of the Python WARC libraries are pretty terrible, `internetarchive/warc`
 (and its various forks) seemed the least bad.
 
 ## Spiders
-All spiders should inherit from `syllascrape.spiders.BaseSpider`.
+All spiders should inherit from `osp_scraper.spiders.OSPSpider`.
 
 `start_urls` is a list of initial URLs to begin the crawl.
 

--- a/osp_scraper/spiders/CustomSpider.py
+++ b/osp_scraper/spiders/CustomSpider.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from . import BaseSpider, ALLOWED_FILE_TYPES
+from . import OSPSpider, ALLOWED_FILE_TYPES
 from ..filterware import Filter
 from ..items import PageItem
 
-class CustomSpider(BaseSpider):
+class CustomSpider(OSPSpider):
     custom_settings = {
-        **BaseSpider.custom_settings,
+        **OSPSpider.custom_settings,
         'ROBOTSTXT_OBEY': False
     }
 

--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -16,7 +16,7 @@ from ..filters import make_filters
 # file types we download
 ALLOWED_FILE_TYPES = frozenset({'pdf', 'doc', 'docx', 'rtf'})
 
-class BaseSpider(scrapy.spiders.Spider):
+class OSPSpider(scrapy.spiders.Spider):
     """Common base class for all syllascrape spiders"""
 
     # Configure item pipelines
@@ -44,7 +44,7 @@ class BaseSpider(scrapy.spiders.Spider):
         }
 
 
-class FilterSpider(BaseSpider):
+class FilterSpider(OSPSpider):
     """Filtering spider.
 
     Parameters


### PR DESCRIPTION
`BaseSpider` is the deprecated name of the `scrapy.spider.Spider` class.
It would be best to have our base spider named something else to avoid
confusion.

Suggested by @HarrisonGregg.