### PR TITLE
Skip 'Database URLs' for general crawls when there's a custom scraper

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -38,7 +38,8 @@ def main(csv_file, local, institution):
                 # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])
                 urls.extend(extract_urls(row['Mixed URLs']))
-                urls.extend(extract_urls(row['Database URLs']))
+                if not row['Custom Scraper Name']:
+                    urls.extend(extract_urls(row['Database URLs']))
 
                 if urls:
                     log.info("Found %d URLs for %s", len(urls), row['name'])


### PR DESCRIPTION
Custom scrapers are typically based on the URL(s) present in 'Database
URLs', and so doing general crawls on them is redundant.