### PR TITLE
Tweaks and improvements for `csv_diff.py`

### DIFF
--- a/bin/csv_diff.py
+++ b/bin/csv_diff.py
@@ -24,6 +24,10 @@ def main(old_csv_file, new_csv_file, out_csv, diff_custom_scrapers):
     Takes in an old edu csv file and a new edu csv, finds the URLs and custom
     scrapers present in the new file but not the old one, and outputs a csv file
     that contains them.
+
+    Rows are compared based on the value in the 'id' column.  In order for the
+    diff to work properly, ensure that each row has a unique 'id' value
+    associated with it.
     """
     with open(old_csv_file) as old_csv, open(new_csv_file) as new_csv:
         old_rows = {row['id']: row for row in csv.DictReader(old_csv)}

--- a/bin/csv_diff.py
+++ b/bin/csv_diff.py
@@ -37,12 +37,10 @@ def main(old_csv_file, new_csv_file, out_csv):
                     + extract_urls(old_row['Mixed URLs'])
                 )
 
-                # NOTE: Currently, the only custom scrapers that use the
-                # database urls are campusconcourse and
-                # campusconcourse_with_files, so we always include database urls
-                # for those rows.  In the future, other custom scrapers might
-                # also need database urls.
-                if "campusconcourse" not in new_row['Custom Scraper Name']:
+                # Always include un-diffed 'Database URLs' for rows that have a
+                # custom scraper in case those 'Database URLs' are used by that
+                # scraper.
+                if not new_row['Custom Scraper Name']:
                     new_database_urls = extract_urls(new_row['Database URLs'])
                     diff_row['Database URLs'] = ",".join(set(new_database_urls) - old_urls)
 

--- a/bin/csv_diff.py
+++ b/bin/csv_diff.py
@@ -14,7 +14,12 @@ def extract_urls(s):
 @click.argument('old_csv_file', type=click.Path(exists=True))
 @click.argument('new_csv_file', type=click.Path(exists=True))
 @click.argument('out_csv', type=click.File('w'))
-def main(old_csv_file, new_csv_file, out_csv):
+@click.option(
+    '--diff_custom_scrapers', default=False, is_flag=True,
+    help=("Consider custom scrapers as part of the diff.  Without this flag, "
+          "rows containing 'Custom Scraper Name's are always included in "
+          "OUT_CSV."))
+def main(old_csv_file, new_csv_file, out_csv, diff_custom_scrapers):
     """
     Takes in an old edu csv file and a new edu csv, finds the URLs and custom
     scrapers present in the new file but not the old one, and outputs a csv file
@@ -37,10 +42,14 @@ def main(old_csv_file, new_csv_file, out_csv):
                     + extract_urls(old_row['Mixed URLs'])
                 )
 
+                if diff_custom_scrapers:
+                    if new_row['Custom Scraper Name'] == old_row['Custom Scraper Name']:
+                        diff_row['Custom Scraper Name'] = ""
+
                 # Always include un-diffed 'Database URLs' for rows that have a
                 # custom scraper in case those 'Database URLs' are used by that
                 # scraper.
-                if not new_row['Custom Scraper Name']:
+                if not diff_row['Custom Scraper Name']:
                     new_database_urls = extract_urls(new_row['Database URLs'])
                     diff_row['Database URLs'] = ",".join(set(new_database_urls) - old_urls)
 

--- a/bin/csv_diff.py
+++ b/bin/csv_diff.py
@@ -26,14 +26,14 @@ def main(old_csv_file, new_csv_file, out_csv, diff_custom_scrapers):
     that contains them.
     """
     with open(old_csv_file) as old_csv, open(new_csv_file) as new_csv:
-        old_rows = {row['name']: row for row in csv.DictReader(old_csv)}
+        old_rows = {row['id']: row for row in csv.DictReader(old_csv)}
 
         new_reader = csv.DictReader(new_csv)
         writer = csv.DictWriter(out_csv, fieldnames=new_reader.fieldnames)
         writer.writeheader()
         for new_row in new_reader:
             diff_row = dict(new_row)
-            old_row = old_rows.get(new_row['name'])
+            old_row = old_rows.get(new_row['id'])
 
             if old_row:
                 old_urls = set(


### PR DESCRIPTION
- Always preserve `database_urls` if there's a custom scraper.
- Adds a `--diff_custom_scrapers` option, which considers custom scrapers as part of the diff (i.e., custom scrapers that are in both OLD_CSV and NEW_CSV won't be run again).
- Compare rows based on 'id', not 'name'.
- Documentation updates.

If there are any other ideas for tweaking or improving the script, this would be a good place to implement them.