### PR TITLE
Add string cast to prevent errors with port filters

### DIFF
--- a/osp_scraper/filterware.py
+++ b/osp_scraper/filterware.py
@@ -143,7 +143,8 @@ class Filter:
         ret = True
 
         for name, regex in self._url_regexes.items():
-            if regex is not None and not regex.match(getattr(url, name) or ''):
+            attribute = str(getattr(url, name, ''))
+            if regex is not None and not regex.match(attribute):
                 ret = False
                 break
 


### PR DESCRIPTION
Currently, when `osp_scraper_spider` tries to run with a URL that includes a port in `start_urls`, it fails with this error:
```python
Traceback (most recent call last):
  File "/home/harrison/Documents/osp-scraper/env/lib/python3.6/site-packages/scrapy/utils/defer.py", line 102, in iter_errback
    yield next(it)
  File "/home/harrison/Documents/osp-scraper/osp_scraper/spidermiddlewares.py", line 35, in process_spider_output
    allowed, filter = check_filters(spider.filters, request)
  File "/home/harrison/Documents/osp-scraper/osp_scraper/filterware.py", line 23, in check_filters
    if f(request):
  File "/home/harrison/Documents/osp-scraper/osp_scraper/filterware.py", line 146, in __call__
    if regex is not None and not regex.match(getattr(url, name) or ''):
TypeError: expected string or bytes-like object
```
This is because the filterware tries to call `regex.match` on `url.port`, which is an int, not a string.  This was presumably causing the scraper to fail on all URLs from the spreadsheet that contained a port. This PR fixes the problem by casting all attribute values being evaluated to strings. 