### PR TITLE
Add Scrapy templates for our spider types

### DIFF
--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -110,6 +110,10 @@ SPIDER_MIDDLEWARES = {
 #HTTPCACHE_IGNORE_HTTP_CODES = []
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
 
+# Templates
+# XXX: Is there a clean way to avoid this import?
+import osp_scraper
+TEMPLATES_DIR = os.path.join(osp_scraper.__path__[0], 'templates')
 
 # ENV
 

--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -17,7 +17,7 @@ import os
 BOT_NAME = 'osp_scraper'
 
 SPIDER_MODULES = ['osp_scraper.spiders', 'osp_site_scrapers']
-NEWSPIDER_MODULE = 'osp_scraper.spiders'
+NEWSPIDER_MODULE = 'osp_site_scrapers'
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent
 #USER_AGENT = 'osp_scraper (+http://www.yourdomain.com)'

--- a/osp_scraper/templates/spiders/mapper.tmpl
+++ b/osp_scraper/templates/spiders/mapper.tmpl
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import scrapy
+
+from osp_scraper.spiders import FilterSpider
+
+class $classname(FilterSpider):
+    name = "$name"
+
+    start_urls = ["$domain"]
+
+    def parse(self, response):
+        pass

--- a/osp_scraper/templates/spiders/scraper.tmpl
+++ b/osp_scraper/templates/spiders/scraper.tmpl
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import scrapy
+
+from osp_scraper.spiders.CustomSpider import CustomSpider
+
+class $classname(CustomSpider):
+    name = "$name"
+
+    start_urls = ["$domain"]
+
+    def parse(self, response):
+        pass


### PR DESCRIPTION
Not super useful, just something fun I thought of.

To test, run
```
scrapy genspider -t [scraper|mapper] [name] [start_url]
```

Scrapy templates are pretty limited in their capabilities as far as I can tell, so much of the time the output of the `genspider` command will still need tweaking, but in theory these templates will still _greatly_ optimize our workflow ;)
