### PR TITLE
Add script for queuing seed URLs

### DIFF
--- a/bin/queue_seed_urls.py
+++ b/bin/queue_seed_urls.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+from collections import defaultdict
+import logging
+from urllib.parse import urlparse
+
+import click
+
+from osp_scraper.tasks import get_crawl_job
+
+
+log = logging.getLogger('seed_url_crawler')
+
+
+@click.command()
+@click.argument('path', type=click.Path(exists=True))
+def main(path):
+    groups = defaultdict(list)
+    for url in open(path):
+        domain = urlparse(url.strip()).netloc
+        groups[domain].append(url.strip())
+
+    queue_crawl = get_crawl_job(timeout='24h')
+    for domain, urls in groups.items():
+        queue_crawl(
+            'osp_scraper_spider',
+            start_urls=urls,
+            ignore_robots_txt=True
+        )
+
+        log.info(f'{len(urls)} URLs for {domain}')
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/bin/queue_seed_urls.py
+++ b/bin/queue_seed_urls.py
@@ -14,13 +14,20 @@ log = logging.getLogger('seed_url_crawler')
 
 @click.command()
 @click.argument('path', type=click.Path(exists=True))
-def main(path):
+@click.option('--timeout', default="24h", help="Maximum runtime of the jobs")
+def main(path, timeout):
+    """Starts spiders for individual URLs in a text file.
+
+    Takes one input file, which should contain a URL on each line.
+    This script groups the URLs by domain and queues a spider job
+    for each domain.
+    """
     groups = defaultdict(list)
     for url in open(path):
         domain = urlparse(url.strip()).netloc
         groups[domain].append(url.strip())
 
-    queue_crawl = get_crawl_job(timeout='24h')
+    queue_crawl = get_crawl_job(timeout=timeout)
     for domain, urls in groups.items():
         queue_crawl(
             'osp_scraper_spider',

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -29,3 +29,11 @@ def crawl(spider, *args, **kwargs):
     proc = CrawlerProcess(settings)
     proc.crawl(spider, *args, **kwargs)
     proc.start()
+
+def get_crawl_job(timeout='24h'):
+    """Returns a function that will add a crawl call to the Redis queue
+
+    Args:
+        timeout (int/string): the maximum runtime of the job
+    """
+    return job('default', connection=redis_conn, timeout=timeout)(crawl).delay


### PR DESCRIPTION
@davidmcclure I've refactored your script for queuing the seed URLs.  The key changes are:

1.  It seemed a little unnecessary to have an entire file for grouping URLs by domain when the functionality of the file was just a few lines.  If you think that grouping by domain is something we might need to use in other places though, we could also move it into a method in `utils.py`.
2. I added a method to `tasks.py` that makes it easy to specify `timeout` when queuing jobs.  I'll add it to `edu_repo_crawler.py` in a separate PR.