### PR TITLE
Clean up crawl queuing

### DIFF
--- a/bin/download_files.py
+++ b/bin/download_files.py
@@ -4,7 +4,7 @@ import logging
 
 import click
 
-from osp_scraper.tasks import crawl
+from osp_scraper.tasks import crawl, get_crawl_job
 
 log = logging.getLogger('file_crawler')
 
@@ -17,7 +17,7 @@ log = logging.getLogger('file_crawler')
     help="Run spiders locally instead of queueing them"
 )
 def main(csv_file, local):
-    crawl_func = crawl if local else crawl.delay
+    crawl_func = crawl if local else get_crawl_job("168h")
 
     crawl_func("file_downloader", csv_file=csv_file)
 

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -5,7 +5,7 @@ import logging
 
 import click
 
-from osp_scraper.tasks import crawl
+from osp_scraper.tasks import crawl, get_crawl_job
 from osp_scraper.utils import extract_urls
 
 
@@ -16,7 +16,7 @@ log = logging.getLogger('edu_repo_crawler')
 @click.option('--local', default=False, is_flag=True, help='Run one spider locally instead of queueing it')
 @click.option('--institution', default=None, help='Only run spiders for the institution with this ID')
 def main(csv_file, local, institution):
-    crawl_func = crawl if local else crawl.delay
+    crawl_func = crawl if local else get_crawl_job("168h")
 
     with open(csv_file) as f:
         for row in csv.DictReader(f):

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -29,3 +29,11 @@ def crawl(spider, *args, **kwargs):
     proc = CrawlerProcess(settings)
     proc.crawl(spider, *args, **kwargs)
     proc.start()
+
+def get_crawl_job(timeout='24h'):
+    """Returns a function that will add a crawl call to the Redis queue
+
+    Args:
+        timeout (int/string): the maximum runtime of the job
+    """
+    return job('default', connection=redis_conn, timeout=timeout)(crawl).delay

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -14,8 +14,6 @@ from .spiders import FilterSpider
 from .filterware import Filter
 from .services import redis_conn
 
-# Run crawls for 1 day max.
-@job('default', connection=redis_conn, timeout=86400)
 def crawl(spider, *args, **kwargs):
     """Run a spider.
 


### PR DESCRIPTION
This adds a method to `tasks.py` that makes it easy to specify `timeout` when queuing jobs.  It also switches to using the hour format supported by rq to make the times more readable.  