### PR TITLE
Add ScraperWorker class

### DIFF
--- a/osp_scraper/workers.py
+++ b/osp_scraper/workers.py
@@ -1,0 +1,20 @@
+
+
+from rq import Worker
+
+
+class ScraperWorker(Worker):
+
+    def request_stop(self, *args, **kwargs):
+        """When SIGINT is sent to the worker (eg, if the Supervisor process
+        group is restarted), immediately fail the running job and stop the
+        worker. This avoids a scenario in which the worker gets shut down but
+        not unregistered in Redis, causing it to get "marooned" in the admin.
+        """
+        job = self.get_current_job()
+
+        if job:
+            self.handle_job_failure(job)
+            self.failed_queue.quarantine(job, 'Worker shutdown.')
+
+        self.request_force_stop(*args, **kwargs)


### PR DESCRIPTION
Used by osp-deploy as of
opensyllabus/osp-deploy@9b4a1b7b1d30d32aca5467465b2e661b80a738cd.

From the `deploy` branch, and split off from https://github.com/opensyllabus/osp-scraper/pull/142.