### PR TITLE
Disable Telnet console

### DIFF
--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -65,9 +65,9 @@ DOWNLOAD_MAXSIZE = 128 * (1024 * 1024) # 128 MB
 
 # Enable or disable extensions
 # See http://scrapy.readthedocs.org/en/latest/topics/extensions.html
-#EXTENSIONS = {
-#    'scrapy.extensions.telnet.TelnetConsole': None,
-#}
+EXTENSIONS = {
+   'scrapy.extensions.telnet.TelnetConsole': None,
+}
 
 # WARC Pipelines are added at the scraper level
 ITEM_PIPELINES = {}


### PR DESCRIPTION
Unused by us and avoids port conflicts when multiple crawls are running
on the same machine.

From the `deploy` branch.