### PR TITLE
Allow for multiple custom scrapers per row

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -27,7 +27,11 @@ def main(csv_file, local, institution):
                     params = {
                         "database_urls": extract_urls(row['Database URLs'])
                     }
-                    crawl_func(row['Custom Scraper Name'], **params)
+                    for scraper_name in row['Custom Scraper Name'].split(","):
+                        crawl_func(
+                            scraper_name.strip(),
+                            **params
+                        )
 
                 # Find comma-separated URLs in these columns.
                 urls = extract_urls(row['Doc URLs'])

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -21,6 +21,7 @@ def main(csv_file, local, institution):
     with open(csv_file) as f:
         for row in csv.DictReader(f):
             if not institution or institution == row['id']:
+                job = None
                 if row['Custom Scraper Name']:
                     # Create a parameter of database URLs that can be used by
                     # custom scrapers as needed.
@@ -28,8 +29,9 @@ def main(csv_file, local, institution):
                         "database_urls": extract_urls(row['Database URLs'])
                     }
                     for scraper_name in row['Custom Scraper Name'].split(","):
-                        crawl_func(
+                        job = crawl_func(
                             scraper_name.strip(),
+                            depends_on=job,
                             **params
                         )
 
@@ -50,7 +52,7 @@ def main(csv_file, local, institution):
                         params['ignore_robots_txt'] = True
                         log.info("Ignoring robots.txt")
 
-                    crawl_func('osp_scraper_spider', **params)
+                    crawl_func('osp_scraper_spider', depends_on=job, **params)
                 else:
                     log.debug("No URLs found for %s", row['name'])
 

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -28,6 +28,8 @@ def crawl(spider, *args, **kwargs):
     except KeyError as err:
         # Log a warning if the scraper name is invalid instead of
         # causing the job to fail.
+        # NOTE: If there is any other type of error, the job will fail, and all
+        # the jobs that depend on it will fail as well.
         logger.warning(err.args[0])
 
 
@@ -59,6 +61,9 @@ class LocalQueue():
                 except KeyError as err:
                     # Log a warning if the scraper name is invalid instead of
                     # causing the job to fail.
+                    # NOTE: If there is any other type of error, the job will
+                    # fail, and all the jobs that depend on it will fail as
+                    # well.
                     logger.warning(err.args[0])
 
             # XXX: If all the names fail, then trying to run

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -60,7 +60,17 @@ class LocalQueue():
                     # Log a warning if the scraper name is invalid instead of
                     # causing the job to fail.
                     logger.warning(err.args[0])
-            reactor.stop()
+
+            # XXX: If all the names fail, then trying to run
+            # `reactor.stop()` will give an "Unhandled error in
+            # Deferred" complaint and hang.  It will also hang in
+            # general if no spiders have been run.  I assume there's
+            # some twisted-way to handle this, but for now, just log an
+            # error.
+            if reactor.running:
+                reactor.stop()
+            else:
+                logger.critical("LocalQueue: No valid scraper names found.")
 
         deferred_crawl()
         reactor.run()


### PR DESCRIPTION
Occasionally one institution uses multiple distinct databases that require distinct custom scrapers.  This change allow specifying multiple comma-separated scraper names in the "Custom Scraper Name" column.

However, this brings up concerns about having too big of an impact on servers by running multiple crawls on the same domain at once, so this also makes a change that causes the crawl jobs in each row to run in sequence instead of (potentially) in parallel.  Each job will wait for the previous job to finish before starting.  

@wearpants @davidmcclure Does this sound reasonable to you?  Does it make sense to run the crawls sequentially even though it could mean it takes a lot longer to run all of the crawls?  The custom scraper crawls shouldn't take as long as the general crawls though, so it shouldn't make too big of a difference.