### PR TITLE
Refactor all depth/hops_from_seed logic into spider middleware

### DIFF
--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -80,9 +80,9 @@ DOWNLOADER_MIDDLEWARES = {
 SPIDER_MIDDLEWARES = {
     # disable builtin middlewares
     'scrapy.spidermiddlewares.offsite.OffsiteMiddleware': None,
-    'scrapy.spidermiddlewares.depth.DepthMiddleware': None,
 
     # use our middlewares instead
+    "osp_scraper.spidermiddlewares.DepthMiddleware": 901,
     'osp_scraper.spidermiddlewares.FilterMiddleware': 500,
 }
 

--- a/osp_scraper/spidermiddlewares.py
+++ b/osp_scraper/spidermiddlewares.py
@@ -26,7 +26,6 @@ class DepthMiddleware(object):
         hops_from_seed = response.meta.get('hops_from_seed', 0)
 
         for obj in result:
-            print("result:", obj)
             if isinstance(obj, PageItem):
                 obj['depth'] = depth
                 obj['hops_from_seed'] = hops_from_seed

--- a/osp_scraper/spidermiddlewares.py
+++ b/osp_scraper/spidermiddlewares.py
@@ -2,10 +2,52 @@ import logging
 
 from scrapy import Request
 
+from .items import PageItem
 from .filterware import check_filters
 
 logger = logging.getLogger(__name__)
 
+class DepthMiddleware(object):
+    """Middleware to set depths and hops_from_seed
+
+    This middleware handles all logic for setting depth and
+    hops_from_seeds on requests and items.
+    """
+
+    def __init__(self, stats):
+        self.stats = stats
+
+    @classmethod
+    def from_crawler(cls, crawler):
+        return cls(crawler.stats)
+
+    def process_spider_output(self, response, result, spider):
+        depth = response.meta.get('depth', 0)
+        hops_from_seed = response.meta.get('hops_from_seed', 0)
+
+        for obj in result:
+            print("result:", obj)
+            if isinstance(obj, PageItem):
+                obj['depth'] = depth
+                obj['hops_from_seed'] = hops_from_seed
+
+                for url, meta in obj['file_urls']:
+                    meta['depth'] = depth + 1
+                    meta['hops_from_seed'] = hops_from_seed + 1
+
+            elif isinstance(obj, Request):
+                obj.meta['depth'] = depth + 1
+                obj.meta['hops_from_seed'] = hops_from_seed + 1
+
+            yield obj
+
+    def process_spider_input(self, response, spider):
+        # This is only necessary for backwards compatibility in custom
+        # scrapers that expect depth and hops_from_seed in response.meta
+        if 'depth' not in response.meta:
+            response.meta['depth'] = 0
+        if 'hops_from_seed' not in response.meta:
+            response.meta['hops_from_seed'] = 0
 
 class FilterMiddleware(object):
     """Middleware to support filters in the spider layer

--- a/osp_scraper/spiders/CustomSpider.py
+++ b/osp_scraper/spiders/CustomSpider.py
@@ -16,20 +16,6 @@ class CustomSpider(OSPSpider):
         spider.filters = [Filter.compile('allow')]
         return spider
 
-    def start_requests(self):
-        """
-        Override in subclass for each site when necessary.  Overriding
-        start_requests is not necessary when implementing parse.
-
-        By default, sets both the 'depth' and 'hops_from_seed' meta content to
-        0.  This can be useful when making calls to parse_for_files directly out
-        of parse.
-        """
-        for request in super().start_requests():
-            request.meta['depth'] = 0
-            request.meta['hops_from_seed'] = 0
-            yield request
-
     def parse(self, response):
         """
         Implement in subclass for each site when necessary.  Implementing parse
@@ -60,8 +46,6 @@ class CustomSpider(OSPSpider):
             meta = {
                 'source_url': response.url,
                 'source_anchor': self.clean_whitespace(anchor),
-                'depth': response.meta['depth'] + 1,
-                'hops_from_seed': response.meta['hops_from_seed'] + 1,
             }
 
             file_urls.append((response.urljoin(url), meta))
@@ -77,8 +61,6 @@ class CustomSpider(OSPSpider):
             status=response.status,
             source_url=response.meta['source_url'],
             source_anchor=self.clean_whitespace(response.meta['source_anchor']),
-            depth=response.meta['depth'],
-            hops_from_seed=response.meta['hops_from_seed'],
             file_urls=file_urls
         )
 

--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -78,12 +78,6 @@ class FilterSpider(OSPSpider):
         )
         return spider
 
-    def start_requests(self):
-        for r in super().start_requests():
-            r.meta['depth'] = 0
-            r.meta['hops_from_seed'] = 0
-            yield r
-
     def parse(self, response):
         # we may end up with a binary response here (instead of in `file_urls`) if
         # we are redirected from a `/plain` URL to a binary blob like `/plain.pdf`
@@ -107,8 +101,6 @@ class FilterSpider(OSPSpider):
                 status=response.status,
                 source_url=response.meta.get('source_url'),
                 source_anchor=response.meta.get('source_anchor'),
-                depth = response.meta.get('depth'),
-                hops_from_seed = response.meta.get('hops_from_seed'),
             )
 
     def parse_text(self, response):
@@ -119,8 +111,6 @@ class FilterSpider(OSPSpider):
             meta = {
                 'source_url': response.url,
                 'source_anchor': anchor,
-                'depth': response.meta['depth'] + 1,
-                'hops_from_seed': response.meta['hops_from_seed'] + 1
             }
 
             # if path ends with a known binary file extension download it, otherwise crawl it
@@ -136,8 +126,6 @@ class FilterSpider(OSPSpider):
             status=response.status,
             source_url=response.meta.get('source_url'),
             source_anchor=response.meta.get('source_anchor'),
-            depth = response.meta.get('depth'),
-            hops_from_seed = response.meta.get('hops_from_seed'),
             file_urls = file_urls,
         )
 

--- a/osp_scraper/spiders/file_scraper.py
+++ b/osp_scraper/spiders/file_scraper.py
@@ -19,8 +19,6 @@ class FileDownloader(CustomSpider):
                     yield scrapy.Request(
                         row.get('Document Url'),
                         meta={
-                            'depth': 0,
-                            'hops_from_seed': 0,
                             'source_url': source,
                             'source_anchor': ""
                         },

--- a/osp_scraper/spiders/pdf.py
+++ b/osp_scraper/spiders/pdf.py
@@ -19,8 +19,6 @@ class PDFSpider(CustomSpider):
             yield scrapy.Request(
                 start_url,
                 meta={
-                    'depth': 0,
-                    'hops_from_seed': 0,
                     'source_url': start_url,
                     'source_anchor': start_url
                 },


### PR DESCRIPTION
The primary changes in this PR are to consolidate all logic concerning setting and incrementing `depth` and `hops_from_seed` on requests and items into a new spider middleware.  This simplifies logic somewhat in this project, but will make a more significant impact in the custom scrapers, which will no longer have to include any `depth`/`hops_from_seed` logic at all.  Some code is included for backward compatibility with custom scrapers, but it could be removed after all custom scrapers are updated.

Additionally, this PR removes the line that disables [`scrapy.spidermiddlewares.depth.DepthMiddleware`](https://github.com/scrapy/scrapy/blob/master/scrapy/spidermiddlewares/depth.py).  This middleware does not appear to conflict with our own `depth` logic, and it also sets the priority of requests based on their depth, which should make our spiders behave more consistently.

Testing with the suite in #158 as well as manual tests indicate that these changes do not affect the functionality of any spiders.