### PR TITLE
Clean up imports and remove unnecessary encoding declaration

### DIFF
--- a/bin/csv_diff.py
+++ b/bin/csv_diff.py
@@ -6,6 +6,7 @@ import click
 
 from osp_scraper.utils import extract_urls
 
+
 @click.command()
 @click.argument('old_csv_file', type=click.Path(exists=True))
 @click.argument('new_csv_file', type=click.Path(exists=True))
@@ -64,6 +65,7 @@ def main(old_csv_file, new_csv_file, out_csv, diff_custom_scrapers):
                     or diff_row['Doc URLs']
                     or diff_row['Mixed URLs']):
                 writer.writerow(diff_row)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/csv_filter.py
+++ b/bin/csv_filter.py
@@ -4,6 +4,7 @@ import csv
 
 import click
 
+
 @click.command()
 @click.argument('in_csv_file', type=click.File('r'))
 @click.argument('out_csv', type=click.File('w'))
@@ -26,6 +27,7 @@ def main(in_csv_file, out_csv, scraper_names, only_database):
                 row['Mixed URLs'] = ""
 
             writer.writerow(row)
+
 
 if __name__ == '__main__':
     main()

--- a/bin/download_files.py
+++ b/bin/download_files.py
@@ -8,6 +8,7 @@ from osp_scraper.tasks import crawl, get_crawl_job
 
 log = logging.getLogger('file_crawler')
 
+
 @click.command()
 @click.argument('csv_file', type=click.Path(exists=True))
 @click.option(
@@ -20,6 +21,7 @@ def main(csv_file, local):
     crawl_func = crawl if local else get_crawl_job("168h")
 
     crawl_func("file_downloader", csv_file=csv_file)
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -8,8 +8,8 @@ import click
 from osp_scraper.tasks import crawl, get_crawl_job
 from osp_scraper.utils import extract_urls
 
-
 log = logging.getLogger('edu_repo_crawler')
+
 
 @click.command()
 @click.argument('csv_file', type=click.Path(exists=True))
@@ -53,6 +53,7 @@ def main(csv_file, local, institution):
 
                 if institution:
                     break
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/bin/osp_scraper_spider.py
+++ b/bin/osp_scraper_spider.py
@@ -8,6 +8,7 @@ from osp_scraper.tasks import crawl
 
 log = logging.getLogger('edu_repo_crawler')
 
+
 @click.command()
 @click.argument('url')
 def main(url):
@@ -16,6 +17,7 @@ def main(url):
     }
 
     crawl('osp_scraper_spider', **params)
+
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)

--- a/bin/queue_seed_urls.py
+++ b/bin/queue_seed_urls.py
@@ -37,6 +37,7 @@ def main(path, timeout):
 
         log.info(f'{len(urls)} URLs for {domain}')
 
+
 if __name__ == '__main__':
     logging.basicConfig(level=logging.INFO)
     main()

--- a/osp_scraper/downloadermiddlewares.py
+++ b/osp_scraper/downloadermiddlewares.py
@@ -1,4 +1,3 @@
-import re
 import logging
 
 from scrapy import Request
@@ -7,6 +6,7 @@ from scrapy.exceptions import IgnoreRequest
 from .filterware import check_filters
 
 logger = logging.getLogger(__name__)
+
 
 class FilterMiddleware(object):
     """Middleware to support filters in the downloading layer."""

--- a/osp_scraper/filterware.py
+++ b/osp_scraper/filterware.py
@@ -1,15 +1,15 @@
-import logging
 import fnmatch
+import logging
 import re
 import urllib.parse
-import attr
-import os
 
+import attr
 from scrapy import signals
 from scrapy.http import Request
 from scrapy.utils.httpobj import urlparse_cached
 
 logger = logging.getLogger(__name__)
+
 
 def check_filters(filters, request):
     """Check a list of filters
@@ -32,10 +32,12 @@ def check_filters(filters, request):
 
 ## attr validators for internal use in Filter
 
+
 def _positive_int(instance, attribute, value):
     """attr validator that accepts positive ints"""
     if not isinstance(value, int) or value <= 0:
         raise ValueError('%s must be a strictly positive int' % attribute.name)
+
 
 def _one_of(allowed_values):
     """construct an attr validator that accepts only `allowed_values`"""
@@ -43,6 +45,7 @@ def _one_of(allowed_values):
     def _valid(instance, attribute, value):
         if value not in allowed_values:
             raise ValueError('%s must be one of %r' % (value, allowed_values))
+
 
 def _dict_of_str_str(instance, attribute, value):
     """attr validator that accepts dict of str => str"""
@@ -53,8 +56,10 @@ def _dict_of_str_str(instance, attribute, value):
         if not isinstance(k, str) or not isinstance(v, str):
             raise TypeError('%s must contain strings', attribute.name)
 
+
 # an optional string attr validator
 _optional_str = attr.validators.optional(attr.validators.instance_of(str))
+
 
 @attr.s(cmp=False)
 class Filter:

--- a/osp_scraper/items.py
+++ b/osp_scraper/items.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
-
 # Define here the models for your scraped items
 #
 # See documentation in:
 # http://doc.scrapy.org/en/latest/topics/items.html
 
-import scrapy
 from pprint import pformat
+
+import scrapy
+
 
 class PageItem(scrapy.Item):
     url = scrapy.Field()

--- a/osp_scraper/pipelines.py
+++ b/osp_scraper/pipelines.py
@@ -1,30 +1,28 @@
-# -*- coding: utf-8 -*-
-
-import scrapy
-from scrapy.pipelines.files import FilesPipeline
-from scrapy.utils.python import to_bytes
-from scrapy.utils.misc import md5sum
-
-import warc
-import httpstatus
-
-import socket
-import uuid
-import logging
-import os.path
-import time
-import json
 import itertools
 from io import BytesIO
+import json
+import logging
+import os.path
+import socket
+import time
+import uuid
 from urllib.parse import urlparse
+
+import httpstatus
+import scrapy
+from scrapy.pipelines.files import FilesPipeline
+from scrapy.utils.misc import md5sum
+import warc
 
 from . import items
 from .version import git_revision
+
 
 def path_from_warc(record, prefix=""):
     """return a path from the Record ID of a WARC"""
     path = "%s.warc" % record.header.record_id[10:-1]
     return os.path.join(prefix, path)
+
 
 def new_warc(kind):
     """return a new WARCRecord
@@ -43,6 +41,7 @@ def new_warc(kind):
 
     return warc.WARCRecord(header=warc.WARCHeader(headers, defaults=False),
                            defaults=False)
+
 
 def update_warc_info_from_spider(record, spider):
     """update a WARC warcinfo record from a scrapy Spider"""
@@ -84,6 +83,7 @@ def update_warc_response_from_item(record, item):
                                                        (item['content'], )
                                                        )))
 
+
 def update_warc_metadata_from_item(record, item):
     """update a WARC metadata record from a scrapy Item"""
 
@@ -98,6 +98,7 @@ def update_warc_metadata_from_item(record, item):
     buf = BytesIO()
     fields.write_to(buf, version_line=False, extra_crlf=False)
     record.update_payload(buf.getvalue())
+
 
 class WarcStorePipeline(object):
     """Stores web pages in WARC files, similar to `FilesPipeline`.
@@ -168,6 +169,7 @@ class WarcStorePipeline(object):
         metadata.write_to(buf)
         self.store.persist_file(path, buf, None)
         return item
+
 
 class WarcFilesPipeline(FilesPipeline):
     """A customized `FilesPipeline`

--- a/osp_scraper/pipelines.py
+++ b/osp_scraper/pipelines.py
@@ -1,3 +1,4 @@
+import http
 import itertools
 from io import BytesIO
 import json
@@ -8,7 +9,6 @@ import time
 import uuid
 from urllib.parse import urlparse
 
-import httpstatus
 import scrapy
 from scrapy.pipelines.files import FilesPipeline
 from scrapy.utils.misc import md5sum
@@ -74,7 +74,7 @@ def update_warc_response_from_item(record, item):
 
     # XXX scrapy doesn't provide human-readable status string
     status = "HTTP/1.1 {} {}".format(item['status'],
-                                     httpstatus.HTTPStatus(item['status']).name).encode()
+                                     http.HTTPStatus(item['status']).name).encode()
     headers = [b': '.join((k, v)) for k, l in item['headers'].iteritems() for v in l]
 
     record.update_payload(b"\r\n".join(itertools.chain((status, ),
@@ -258,7 +258,7 @@ class WarcFilesPipeline(FilesPipeline):
 
     def _check_media_to_download(self, result, request, info):
         # By default, scrapy will not follow redirects when downloading files.
-        # This allows the file pipeline to follow redirects instead of just giving a 
+        # This allows the file pipeline to follow redirects instead of just giving a
         # warning and not downloading the file.
         x = super()._check_media_to_download(result, request, info)
         request.meta['handle_httpstatus_all'] = False

--- a/osp_scraper/services.py
+++ b/osp_scraper/services.py
@@ -1,8 +1,5 @@
-
-
 from redis import Redis
 
 from .settings.rq import REDIS_URL
-
 
 redis_conn = Redis.from_url(REDIS_URL)

--- a/osp_scraper/settings/__init__.py
+++ b/osp_scraper/settings/__init__.py
@@ -1,4 +1,3 @@
+from dotenv import find_dotenv, load_dotenv
 
-
-from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())

--- a/osp_scraper/settings/rq.py
+++ b/osp_scraper/settings/rq.py
@@ -1,7 +1,4 @@
-
-
 import os
-
 
 REDIS_URL = os.environ.get(
     'REDIS_URL', 'redis://localhost/0'

--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -9,6 +9,8 @@
 
 import os
 
+from .. import templates
+
 BOT_NAME = 'osp_scraper'
 
 SPIDER_MODULES = ['osp_scraper.spiders', 'osp_site_scrapers']
@@ -106,9 +108,7 @@ SPIDER_MIDDLEWARES = {
 #HTTPCACHE_STORAGE = 'scrapy.extensions.httpcache.FilesystemCacheStorage'
 
 # Templates
-# XXX: Is there a clean way to avoid this import?
-import osp_scraper
-TEMPLATES_DIR = os.path.join(osp_scraper.__path__[0], 'templates')
+TEMPLATES_DIR = templates.__path__._path[0]
 
 # ENV
 

--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -1,6 +1,3 @@
-
-# -*- coding: utf-8 -*-
-
 # Scrapy settings for osp_scraper project
 #
 # For simplicity, this file contains only settings considered important or
@@ -10,9 +7,7 @@
 #     http://scrapy.readthedocs.org/en/latest/topics/downloader-middleware.html
 #     http://scrapy.readthedocs.org/en/latest/topics/spider-middleware.html
 
-
 import os
-
 
 BOT_NAME = 'osp_scraper'
 

--- a/osp_scraper/spidermiddlewares.py
+++ b/osp_scraper/spidermiddlewares.py
@@ -1,11 +1,11 @@
 import logging
-import re
 
 from scrapy import Request
 
 from .filterware import check_filters
 
 logger = logging.getLogger(__name__)
+
 
 class FilterMiddleware(object):
     """Middleware to support filters in the spider layer

--- a/osp_scraper/spiders/CustomSpider.py
+++ b/osp_scraper/spiders/CustomSpider.py
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
-from . import OSPSpider, ALLOWED_FILE_TYPES
 from ..filterware import Filter
 from ..items import PageItem
+from . import ALLOWED_FILE_TYPES, OSPSpider
+
 
 class CustomSpider(OSPSpider):
     custom_settings = {

--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -1,20 +1,17 @@
-import scrapy.spiders
-import scrapy.http
-from scrapy.utils.httpobj import urlparse_cached
-
-from urllib.parse import urlparse
 import os.path
 import re
 import uuid
 
+import scrapy.http
+from scrapy.utils.httpobj import urlparse_cached
+
+from ..filters import make_filters
 from ..items import PageItem
 from ..utils import guess_extension
-from .. import version
-from ..filterware import Filter
-from ..filters import make_filters
 
 # file types we download
 ALLOWED_FILE_TYPES = frozenset({'pdf', 'doc', 'docx', 'rtf'})
+
 
 class OSPSpider(scrapy.spiders.Spider):
     """Common base class for all syllascrape spiders"""

--- a/osp_scraper/spiders/file_scraper.py
+++ b/osp_scraper/spiders/file_scraper.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import csv
 from itertools import groupby
 from operator import itemgetter
@@ -7,6 +5,7 @@ from operator import itemgetter
 import scrapy
 
 from ..spiders.CustomSpider import CustomSpider
+
 
 class FileDownloader(CustomSpider):
     name = "file_downloader"

--- a/osp_scraper/spiders/pdf.py
+++ b/osp_scraper/spiders/pdf.py
@@ -1,11 +1,10 @@
-# -*- coding: utf-8 -*-
-
 from io import BytesIO
 
 import PyPDF2 as pyPdf
 import scrapy
 
 from ..spiders.CustomSpider import CustomSpider
+
 
 class PDFSpider(CustomSpider):
     """

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -1,18 +1,9 @@
-
-
-from __future__ import absolute_import
-
-import re
-import urllib.parse
-import os
-
+from rq.decorators import job
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
-from rq.decorators import job
 
-from .spiders import FilterSpider
-from .filterware import Filter
 from .services import redis_conn
+
 
 def crawl(spider, *args, **kwargs):
     """Run a spider.
@@ -27,6 +18,7 @@ def crawl(spider, *args, **kwargs):
     proc = CrawlerProcess(settings)
     proc.crawl(spider, *args, **kwargs)
     proc.start()
+
 
 def get_crawl_job(timeout='24h'):
     """Returns a function that will add a crawl call to the Redis queue

--- a/osp_scraper/templates/spiders/mapper.tmpl
+++ b/osp_scraper/templates/spiders/mapper.tmpl
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
 import scrapy
 
 from osp_scraper.spiders import FilterSpider
+
 
 class $classname(FilterSpider):
     name = "$name"

--- a/osp_scraper/templates/spiders/scraper.tmpl
+++ b/osp_scraper/templates/spiders/scraper.tmpl
@@ -1,8 +1,7 @@
-# -*- coding: utf-8 -*-
-
 import scrapy
 
 from osp_scraper.spiders.CustomSpider import CustomSpider
+
 
 class $classname(CustomSpider):
     name = "$name"

--- a/osp_scraper/utils.py
+++ b/osp_scraper/utils.py
@@ -1,9 +1,6 @@
-from urllib.parse import urlparse
-from scrapy.utils.python import to_bytes
-import os.path
-import hashlib
-import logging
 import mimetypes
+from urllib.parse import urlparse
+
 
 def extract_domain(url):
     """return the domain, with implied port"""
@@ -14,11 +11,13 @@ def extract_domain(url):
         return "%s%s" % (u.netloc,
                          ':80' if u.scheme == 'http' else ':443' if u.scheme == 'https' else '' )
 
+
 def extract_urls(s):
     """Return a list of clean URLs from a comma-separated string."""
     urls = (u.strip() for u in s.split(','))
     urls = (u for u in urls if u.startswith('http'))
     return list(urls)
+
 
 def guess_extension(mimetype):
     """guess a file extension from mimetype, without leading `.`

--- a/osp_scraper/version.py
+++ b/osp_scraper/version.py
@@ -1,9 +1,11 @@
-import subprocess
 import os.path
+import subprocess
+
 
 # helper func to get revision from a development checkout
 def get_git_revision_short_hash():
     return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+
 
 fname = os.path.join(os.path.dirname(__file__), 'git_revision')
 if os.path.exists(fname):

--- a/osp_scraper/workers.py
+++ b/osp_scraper/workers.py
@@ -1,5 +1,3 @@
-
-
 from rq import Worker
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ cryptography==1.9
 cssselect==1.0.1
 decorator==4.0.11
 Flask==0.12.2
-httpstatus35==0.0.1
 hyperlink==17.1.1
 idna==2.5
 incremental==17.5.0


### PR DESCRIPTION
This PR:
- Removes unused imports
- Organize imports per PEP8 guidelines
- Removes `# -*- coding: utf-8 -*-` from a few files, since it's unnecessary in Python 3
- Remove blank lines at the beginning of files
- Fix spacing so that there is 1 line after imports, but 2 lines surrounding top level class and function declarations, per PEP8
- Remove `httpstatus35` requirement and replace usage with `http` from standard library