### PR TITLE
Fix iteritems -> items, for Python 3.

### DIFF
--- a/osp_scraper/pipelines.py
+++ b/osp_scraper/pipelines.py
@@ -76,7 +76,7 @@ def update_warc_response_from_item(record, item):
     # XXX scrapy doesn't provide human-readable status string
     status = "HTTP/1.1 {} {}".format(item['status'],
                                      httpstatus.HTTPStatus(item['status']).name).encode()
-    headers = [b': '.join((k, v)) for k, l in item['headers'].iteritems() for v in l]
+    headers = [b': '.join((k, v)) for k, l in item['headers'].items() for v in l]
 
     record.update_payload(b"\r\n".join(itertools.chain((status, ),
                                                        headers,
@@ -256,7 +256,7 @@ class WarcFilesPipeline(FilesPipeline):
 
     def _check_media_to_download(self, result, request, info):
         # By default, scrapy will not follow redirects when downloading files.
-        # This allows the file pipeline to follow redirects instead of just giving a 
+        # This allows the file pipeline to follow redirects instead of just giving a
         # warning and not downloading the file.
         x = super()._check_media_to_download(result, request, info)
         request.meta['handle_httpstatus_all'] = False


### PR DESCRIPTION
Landing a fix that Jody and I made a couple weeks ago on the deploy branch, which I just noticed never made it into master - in the `pipelines` module, there was an `.iteritems()` call on a dictionary, which breaks in Python 3, where it's just `.items()`.

This is the last unmerged change on `deploy`, which I'll get rid of. Going forward let's just deploy from master.