### PR TITLE
Settings update

### DIFF
--- a/bin/edu_repo_crawler.py
+++ b/bin/edu_repo_crawler.py
@@ -48,10 +48,6 @@ def main(csv_file, local, institution):
                     }
                     log.debug("Params: %r", params)
 
-                    if row['robots.txt'].strip().lower() == "ignore":
-                        params['ignore_robots_txt'] = True
-                        log.info("Ignoring robots.txt")
-
                     crawl_func('osp_scraper_spider', depends_on=job, **params)
                 else:
                     log.debug("No URLs found for %s", row['name'])

--- a/osp_scraper/settings/scrapy.py
+++ b/osp_scraper/settings/scrapy.py
@@ -16,14 +16,15 @@ BOT_NAME = 'osp_scraper'
 SPIDER_MODULES = ['osp_scraper.spiders', 'osp_site_scrapers']
 NEWSPIDER_MODULE = 'osp_site_scrapers'
 
-# Crawl responsibly by identifying yourself (and your website) on the user-agent
-#USER_AGENT = 'osp_scraper (+http://www.yourdomain.com)'
+# NOTE: Add version number of 'osp-scraper'?
+USER_AGENT = "OSPScraper (+https://www.opensyllabusproject.org)"
 
-# Obey robots.txt rules
-ROBOTSTXT_OBEY = True
+# Don't follow robots.txt.
+ROBOTSTXT_OBEY = False
 
-# Maximum file size to download
-DOWNLOAD_MAXSIZE = 128 * (1024 * 1024) # 128 MB
+# Maximum file size to download.  This value is currently three times the
+# largest known size of a syllabus in our collection.
+DOWNLOAD_MAXSIZE = 30 * (1024 * 1024) # 30 MiB
 
 # Configure maximum concurrent requests performed by Scrapy (default: 16)
 #CONCURRENT_REQUESTS = 32

--- a/osp_scraper/spiders/CustomSpider.py
+++ b/osp_scraper/spiders/CustomSpider.py
@@ -4,10 +4,6 @@ from . import ALLOWED_FILE_TYPES, OSPSpider
 
 
 class CustomSpider(OSPSpider):
-    custom_settings = {
-        **OSPSpider.custom_settings,
-        'ROBOTSTXT_OBEY': False
-    }
 
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):

--- a/osp_scraper/spiders/__init__.py
+++ b/osp_scraper/spiders/__init__.py
@@ -68,6 +68,13 @@ class FilterSpider(OSPSpider):
 
     name = "osp_scraper_spider"
 
+    custom_settings = {
+        **OSPSpider.custom_settings,
+        # Set download timeout to 1 minute (scrapy default is 3 minutes), which
+        # is more appropriate for broad crawls.
+        'DOWNLOAD_TIMEOUT': 60,
+    }
+
     @classmethod
     def from_crawler(cls, crawler, *args, **kwargs):
         spider = super().from_crawler(crawler, *args, **kwargs)

--- a/osp_scraper/tasks.py
+++ b/osp_scraper/tasks.py
@@ -18,8 +18,6 @@ def crawl(spider, *args, **kwargs):
         spider (str): The Scrapy `name` of the spider.
     """
     settings = get_project_settings()
-    if kwargs.get('ignore_robots_txt') is True:
-        settings.attributes.get('ROBOTSTXT_OBEY').value = False
 
     proc = CrawlerProcess(settings)
     try:


### PR DESCRIPTION
A response to #176.  Sets

- `USER_AGENT: "OSPScraper (+https://www.opensyllabusproject.org)"`
- `ROBOTSTXT_OBEY = False`
- `DOWNLOAD_MAXSIZE = 30 * (1024 * 1024)`

In the settings file, and additionally sets `'DOWNLOAD_TIMEOUT': 60` in the `custom_settings` of FilterSpider.

Also removes little bits of code that conditionally ignored robots.txt, since they're redundant with the new global ignore setting.